### PR TITLE
chore: update calculate and upload kpi script to run every 3h

### DIFF
--- a/.github/workflows/calculate-and-upload-KPIs.yaml
+++ b/.github/workflows/calculate-and-upload-KPIs.yaml
@@ -2,7 +2,7 @@ name: Calculate and Upload KPIs
 
 on:
   schedule:
-    - cron: '0 */2 * * *' # Runs at minute 0 every 2 hours
+    - cron: '0 */3 * * *' # Runs at minute 0 every 3 hours
   workflow_dispatch:
     inputs:
       timestamp:


### PR DESCRIPTION
With this schedule the next run will be at 12 AM UTC (5 pm PDT) so gives another ~3h for the current job to complete