### PR TITLE
chore: Update workflow runtime and have tether use period startTimestamp

### DIFF
--- a/.github/workflows/calculate-and-upload-KPIs.yaml
+++ b/.github/workflows/calculate-and-upload-KPIs.yaml
@@ -2,7 +2,7 @@ name: Calculate and Upload KPIs
 
 on:
   schedule:
-    - cron: '0 */3 * * *' # Runs at minute 0 every 3 hours
+    - cron: '0 * * * *' # Runs at minute 0 every hour
   workflow_dispatch:
     inputs:
       timestamp:

--- a/scripts/calculateKpi.ts
+++ b/scripts/calculateKpi.ts
@@ -58,7 +58,9 @@ async function calculateKpiBatch({
         const calculatedKpi = await calculateKpiHandlers[protocol]({
           address: userAddress,
           // if the referral happened after the start of the period, only calculate KPI from the referral block onwards so that we exclude user activity before the referral
+          // except for the tether campaign, since we check for the referral tag on all txs, so start from the start of the period to reduce defi llama calls
           startTimestamp:
+            protocol !== 'tether-v0' &&
             referralTimestamp.getTime() > startTimestamp.getTime()
               ? referralTimestamp
               : startTimestamp,


### PR DESCRIPTION
tether campaign looks for referrer tag in all txs so no need to start part way through the period, this reduces need for  multiple defi llama calls to get start block which were very slow