### PR TITLE
chore: Remove past campaign with no reward periods

### DIFF
--- a/scripts/uploadCurrentPeriodKpis.ts
+++ b/scripts/uploadCurrentPeriodKpis.ts
@@ -75,6 +75,13 @@ export async function uploadCurrentPeriodKpis(
 
   // Due to the DefiLlama API rate limit, there is no point in parallelising the calculations across campaigns
   for (const campaign of campaignsToCalculate) {
+    if (campaign.rewardsPeriods.length === 0) {
+      console.log(
+        `Campaign ${campaign.protocol} has no rewards periods, skipping`,
+      )
+      continue
+    }
+
     const campaignStartTimestamp = Date.parse(
       campaign.rewardsPeriods[0].startTimestamp,
     )

--- a/src/campaigns.ts
+++ b/src/campaigns.ts
@@ -240,6 +240,14 @@ export const campaigns: Campaign[] = [
     ],
   },
   {
+    providerAddress: '0x5f0a55fad9424ac99429f635dfb9bf20c3360ab8',
+    protocol: 'celo-transactions',
+    rewardsPoolAddress: '0xe2bedafb063e0b7f12607ebcf4636e2690a427a3',
+    networkId: NetworkId['celo-mainnet'],
+    valoraRewardsPoolAddress: null,
+    rewardsPeriods: [], // past campaign
+  },
+  {
     providerAddress: '0xce56ed47c8f2ee8714087c9e48924b1a30bc455c',
     protocol: 'base-v0',
     rewardsPoolAddress: '0xa2a4c1eb286a2efa470d42676081b771bbe9c1c8',

--- a/src/campaigns.ts
+++ b/src/campaigns.ts
@@ -240,14 +240,6 @@ export const campaigns: Campaign[] = [
     ],
   },
   {
-    providerAddress: '0x5f0a55fad9424ac99429f635dfb9bf20c3360ab8',
-    protocol: 'celo-transactions',
-    rewardsPoolAddress: '0xe2bedafb063e0b7f12607ebcf4636e2690a427a3',
-    networkId: NetworkId['celo-mainnet'],
-    valoraRewardsPoolAddress: null,
-    rewardsPeriods: [], // past campaign
-  },
-  {
     providerAddress: '0xce56ed47c8f2ee8714087c9e48924b1a30bc455c',
     protocol: 'base-v0',
     rewardsPoolAddress: '0xa2a4c1eb286a2efa470d42676081b771bbe9c1c8',


### PR DESCRIPTION
Fixes periodic upload job failure [here](https://github.com/divvi-xyz/divvi-protocol/actions/runs/16840464907/job/47710204669). This campaign was not in the upload script campaign list, so reward periods didn't get moved over to new campaigns file [here](https://github.com/divvi-xyz/divvi-protocol/pull/365/files#diff-e2e59ccdf441770c6a95eff037bbf79e3225a6df2e943e145ce534a3886943c4). The campaign is done so can just be removed.

Also added a check in the periodic script to just skip campaigns with no rewards periods