### PR TITLE
chore: notify kpi calc failures when job is cancelled as well

### DIFF
--- a/.github/workflows/calculate-and-upload-KPIs.yaml
+++ b/.github/workflows/calculate-and-upload-KPIs.yaml
@@ -41,7 +41,7 @@ jobs:
             --protocols ${{ github.event.inputs.protocols }} \
             --redis-connection ${{ secrets.REDIS_CONNECTION }}
       - name: Notify Slack on Failure
-        if: failure()
+        if: ${{ failure() || cancelled() }}
         uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
         with:
           webhook: ${{ secrets.SLACK_ON_CALL_WEBHOOK_URL }}


### PR DESCRIPTION
So that we are alerted when a job is cancelled by the next run if stuck