### PR TITLE
feat(contracts): add kpi calculation to reward pool

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Use `ethers` in Hardhat console to interact with the contract:
 ```
 const RewardPool = await ethers.getContractFactory("RewardPool")
 const rewardPool = await RewardPool.attach('0x9fE46736679d2D9a65F0992F2272dE9f3c7fa6e0')
-await rewardPool.rewardFunctionId()
+await rewardPool.rewardFunctionAddress()
 ```
 
 ## Scripts

--- a/contracts/RewardPool.sol
+++ b/contracts/RewardPool.sol
@@ -6,6 +6,7 @@ import {ReentrancyGuard} from '@openzeppelin/contracts/utils/ReentrancyGuard.sol
 import {SafeERC20} from '@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol';
 import {IERC20} from '@openzeppelin/contracts/token/ERC20/IERC20.sol';
 import {Math} from '@openzeppelin/contracts/utils/math/Math.sol';
+import {IRewardFunction} from './rewardFunctions/IRewardFunction.sol';
 
 /**
  * @title Divvi RewardPool
@@ -44,11 +45,14 @@ contract RewardPool is AccessControl, ReentrancyGuard {
   // State variables
   address public poolToken;
   bool public isNativeToken;
-  bytes32 public rewardFunctionId;
+  address public rewardFunctionAddress;
   uint256 public timelock;
   uint256 public totalPendingRewards;
   mapping(address => uint256) public pendingRewards;
   mapping(bytes32 => bool) public processedIdempotencyKeys;
+  mapping(bytes32 => mapping(address => uint256)) public periodKpis;
+  mapping(bytes32 => address[]) private periodUsers;
+  mapping(bytes32 => bool) public processedPeriods;
 
   // Protocol fee state variables
   uint256 public protocolFee;
@@ -57,7 +61,7 @@ contract RewardPool is AccessControl, ReentrancyGuard {
   // Events
   event PoolInitialized(
     address indexed poolToken,
-    bytes32 rewardFunctionId,
+    address rewardFunctionAddress,
     uint256 timelock
   );
   event Deposit(uint256 amount);
@@ -92,6 +96,24 @@ contract RewardPool is AccessControl, ReentrancyGuard {
     uint256 feeAmount,
     uint256 protocolFee
   );
+  event RewardFunctionAddressUpdated(
+    address newRewardFunctionAddress,
+    address previousRewardFunctionAddress
+  );
+  event AddKpi(
+    address indexed user,
+    bytes32 indexed rewardPeriodKey,
+    uint256 amount,
+    uint256 rewardPeriodStart,
+    uint256 rewardPeriodEndExclusive,
+    bytes32 kpiFunctionId
+  );
+  event RewardPeriodProcessed(
+    bytes32 indexed rewardPeriodKey,
+    uint256 rewardPeriodStart,
+    uint256 rewardPeriodEndExclusive,
+    uint256 totalRewardAmount
+  );
 
   // Errors
   error AmountMismatch(uint256 expected, uint256 received);
@@ -120,6 +142,12 @@ contract RewardPool is AccessControl, ReentrancyGuard {
   error AlreadyInitialized();
   error InvalidProtocolFee(uint256 fee);
   error InvalidReserveAddress();
+  error InvalidRewardFunctionAddress();
+  error RewardPeriodInvalid(
+    uint256 rewardPeriodStart,
+    uint256 rewardPeriodEndExclusive
+  );
+  error RewardPeriodAlreadyProcessed(bytes32 rewardPeriodKey);
 
   // This is needed to prevent the implementation from being initialized
   bool private initialized;
@@ -127,7 +155,7 @@ contract RewardPool is AccessControl, ReentrancyGuard {
   /**
    * @dev Initializes the contract
    * @param _poolToken Address of the token used for rewards
-   * @param _rewardFunctionId Bytes32 identifier of the reward function (e.g. git commit hash)
+   * @param _rewardFunctionAddress Implementation address of the reward function
    * @param _owner Address that will have DEFAULT_ADMIN_ROLE
    * @param _manager Address that will have MANAGER_ROLE
    * @param _timelock Timestamp when manager withdrawals will be allowed
@@ -140,7 +168,7 @@ contract RewardPool is AccessControl, ReentrancyGuard {
    */
   function initialize(
     address _poolToken,
-    bytes32 _rewardFunctionId,
+    address _rewardFunctionAddress,
     address _owner,
     address _manager,
     uint256 _timelock,
@@ -156,19 +184,19 @@ contract RewardPool is AccessControl, ReentrancyGuard {
 
     poolToken = _poolToken;
     isNativeToken = (_poolToken == NATIVE_TOKEN_ADDRESS);
-    rewardFunctionId = _rewardFunctionId;
+    rewardFunctionAddress = _rewardFunctionAddress;
 
     _setTimelock(_timelock);
     _setProtocolFee(_protocolFee);
     _setReserveAddress(_reserveAddress);
 
-    emit PoolInitialized(_poolToken, _rewardFunctionId, _timelock);
+    emit PoolInitialized(_poolToken, _rewardFunctionAddress, _timelock);
   }
 
   /**
    * @dev Constructor for direct deployment
    * @param _poolToken Address of the token used for rewards
-   * @param _rewardFunctionId Bytes32 identifier of the reward function (e.g. git commit hash)
+   * @param _rewardFunctionAddress Implementation address of the reward function
    * @param _owner Address that will have DEFAULT_ADMIN_ROLE
    * @param _manager Address that will have MANAGER_ROLE
    * @param _timelock Timestamp when manager withdrawals will be allowed
@@ -177,7 +205,7 @@ contract RewardPool is AccessControl, ReentrancyGuard {
    */
   constructor(
     address _poolToken,
-    bytes32 _rewardFunctionId,
+    address _rewardFunctionAddress,
     address _owner,
     address _manager,
     uint256 _timelock,
@@ -192,13 +220,13 @@ contract RewardPool is AccessControl, ReentrancyGuard {
 
     poolToken = _poolToken;
     isNativeToken = (_poolToken == NATIVE_TOKEN_ADDRESS);
-    rewardFunctionId = _rewardFunctionId;
+    rewardFunctionAddress = _rewardFunctionAddress;
 
     _setTimelock(_timelock);
     _setProtocolFee(_protocolFee);
     _setReserveAddress(_reserveAddress);
 
-    emit PoolInitialized(_poolToken, _rewardFunctionId, _timelock);
+    emit PoolInitialized(_poolToken, _rewardFunctionAddress, _timelock);
   }
 
   /**
@@ -257,6 +285,141 @@ contract RewardPool is AccessControl, ReentrancyGuard {
   }
 
   /**
+   * @dev Allows the owner to add kpis for a reward period
+   * @param kpis Array of kpis to add
+   * @param rewardPeriodStart Start of the reward period (unix timestamp)
+   * @param rewardPeriodEndExclusive End of the reward period (unix timestamp)
+   * @param kpiFunctionId Bytes32 identifier of the kpi function (e.g., github commit hash)
+   * @notice Allowed only for address with DEFAULT_ADMIN_ROLE
+   */
+  function addKpis(
+    IRewardFunction.Kpi[] calldata kpis,
+    uint256 rewardPeriodStart,
+    uint256 rewardPeriodEndExclusive,
+    bytes32 kpiFunctionId
+  ) external onlyRole(DEFAULT_ADMIN_ROLE) {
+    if (rewardPeriodStart >= rewardPeriodEndExclusive)
+      revert RewardPeriodInvalid(rewardPeriodStart, rewardPeriodEndExclusive);
+
+    bytes32 rewardPeriodKey = keccak256(
+      abi.encode(rewardPeriodStart, rewardPeriodEndExclusive)
+    );
+
+    if (processedPeriods[rewardPeriodKey])
+      revert RewardPeriodAlreadyProcessed(rewardPeriodKey);
+
+    for (uint256 i = 0; i < kpis.length; i++) {
+      if (kpis[i].referrerAddress == address(0))
+        revert ZeroAddressNotAllowed(i);
+
+      // if kpi is 0, remove the user from the period if already present
+      if (kpis[i].kpi == 0) {
+        delete periodKpis[rewardPeriodKey][kpis[i].referrerAddress];
+
+        uint256 index = periodUsers[rewardPeriodKey].length;
+
+        for (uint256 j = 0; j < periodUsers[rewardPeriodKey].length; j++) {
+          if (periodUsers[rewardPeriodKey][j] == kpis[i].referrerAddress) {
+            index = j;
+            break;
+          }
+        }
+
+        if (index < periodUsers[rewardPeriodKey].length) {
+          periodUsers[rewardPeriodKey][index] = periodUsers[rewardPeriodKey][
+            periodUsers[rewardPeriodKey].length - 1
+          ];
+          periodUsers[rewardPeriodKey].pop();
+        }
+      } else {
+        if (periodKpis[rewardPeriodKey][kpis[i].referrerAddress] == 0) {
+          periodUsers[rewardPeriodKey].push(kpis[i].referrerAddress);
+        }
+
+        periodKpis[rewardPeriodKey][kpis[i].referrerAddress] = kpis[i].kpi;
+      }
+
+      emit AddKpi(
+        kpis[i].referrerAddress,
+        rewardPeriodKey,
+        kpis[i].kpi,
+        rewardPeriodStart,
+        rewardPeriodEndExclusive,
+        kpiFunctionId
+      );
+    }
+  }
+
+  /**
+   * @dev Allows the owner to process a reward period and distribute rewards
+   * @param rewardPeriodStart Start of the reward period (unix timestamp)
+   * @param rewardPeriodEndExclusive End of the reward period (unix timestamp)
+   * @param totalRewardAmount Total amount of rewards to distribute
+   * @notice Allowed only for address with DEFAULT_ADMIN_ROLE
+   */
+  function processRewardPeriod(
+    uint256 rewardPeriodStart,
+    uint256 rewardPeriodEndExclusive,
+    uint256 totalRewardAmount
+  ) external onlyRole(DEFAULT_ADMIN_ROLE) {
+    bytes32 rewardPeriodKey = keccak256(
+      abi.encode(rewardPeriodStart, rewardPeriodEndExclusive)
+    );
+
+    if (processedPeriods[rewardPeriodKey])
+      revert RewardPeriodAlreadyProcessed(rewardPeriodKey);
+
+    if (periodUsers[rewardPeriodKey].length == 0)
+      revert RewardPeriodInvalid(rewardPeriodStart, rewardPeriodEndExclusive);
+
+    IRewardFunction.Kpi[] memory kpis = new IRewardFunction.Kpi[](
+      periodUsers[rewardPeriodKey].length
+    );
+
+    for (uint256 i = 0; i < periodUsers[rewardPeriodKey].length; i++) {
+      address user = periodUsers[rewardPeriodKey][i];
+      uint256 kpi = periodKpis[rewardPeriodKey][user];
+
+      kpis[i] = IRewardFunction.Kpi({referrerAddress: user, kpi: kpi});
+    }
+
+    IRewardFunction.Reward[] memory rewards = IRewardFunction(
+      rewardFunctionAddress
+    ).calculateReward(kpis, totalRewardAmount);
+
+    uint256[] memory rewardFunctionArgs = new uint256[](2);
+    rewardFunctionArgs[0] = rewardPeriodStart;
+    rewardFunctionArgs[1] = rewardPeriodEndExclusive;
+
+    for (uint256 i = 0; i < rewards.length; i++) {
+      if (rewards[i].reward == 0) continue;
+
+      RewardData memory rewardData = RewardData({
+        user: rewards[i].referrerAddress,
+        amount: rewards[i].reward,
+        idempotencyKey: keccak256(
+          abi.encode(
+            rewards[i].referrerAddress,
+            rewardPeriodStart,
+            rewardPeriodEndExclusive
+          )
+        )
+      });
+
+      _addReward(rewardData, rewardFunctionArgs);
+    }
+
+    emit RewardPeriodProcessed(
+      rewardPeriodKey,
+      rewardPeriodStart,
+      rewardPeriodEndExclusive,
+      totalRewardAmount
+    );
+
+    processedPeriods[rewardPeriodKey] = true;
+  }
+
+  /**
    * @dev Increases amounts available for users to claim with idempotency protection
    * @param rewards Array of reward items to process
    * @param rewardFunctionArgs Arguments used to calculate rewards
@@ -267,49 +430,50 @@ contract RewardPool is AccessControl, ReentrancyGuard {
     uint256[] calldata rewardFunctionArgs
   ) external onlyRole(DEFAULT_ADMIN_ROLE) {
     for (uint256 i = 0; i < rewards.length; i++) {
-      RewardData calldata reward = rewards[i];
+      if (rewards[i].user == address(0)) revert ZeroAddressNotAllowed(i);
+      if (rewards[i].amount == 0) revert RewardAmountMustBeGreaterThanZero(i);
+      if (rewards[i].idempotencyKey == bytes32(0))
+        revert EmptyIdempotencyKey(i);
+      _addReward(rewards[i], rewardFunctionArgs);
+    }
+  }
 
-      if (reward.user == address(0)) revert ZeroAddressNotAllowed(i);
-      if (reward.amount == 0) revert RewardAmountMustBeGreaterThanZero(i);
-      if (reward.idempotencyKey == bytes32(0)) revert EmptyIdempotencyKey(i);
+  function _addReward(
+    RewardData memory reward,
+    uint256[] memory rewardFunctionArgs
+  ) internal {
+    if (!processedIdempotencyKeys[reward.idempotencyKey]) {
+      processedIdempotencyKeys[reward.idempotencyKey] = true;
 
-      if (!processedIdempotencyKeys[reward.idempotencyKey]) {
-        processedIdempotencyKeys[reward.idempotencyKey] = true;
+      uint256 feeAmount = Math.mulDiv(
+        reward.amount,
+        protocolFee,
+        FEE_DENOMINATOR
+      );
 
-        uint256 feeAmount = Math.mulDiv(
-          reward.amount,
-          protocolFee,
-          FEE_DENOMINATOR
-        );
-
-        if (feeAmount > 0) {
-          _transferPoolToken(reserveAddress, feeAmount);
-          emit ProtocolFeeCollected(
-            reward.user,
-            reward.amount,
-            feeAmount,
-            protocolFee
-          );
-        }
-
-        pendingRewards[reward.user] += reward.amount;
-        totalPendingRewards += reward.amount;
-
-        // Old event for backwards compatibility
-        emit AddReward(reward.user, reward.amount, rewardFunctionArgs);
-        emit AddRewardWithIdempotency(
+      if (feeAmount > 0) {
+        _transferPoolToken(reserveAddress, feeAmount);
+        emit ProtocolFeeCollected(
           reward.user,
           reward.amount,
-          reward.idempotencyKey,
-          rewardFunctionArgs
-        );
-      } else {
-        emit AddRewardSkipped(
-          reward.user,
-          reward.amount,
-          reward.idempotencyKey
+          feeAmount,
+          protocolFee
         );
       }
+
+      pendingRewards[reward.user] += reward.amount;
+      totalPendingRewards += reward.amount;
+
+      // Old event for backwards compatibility
+      emit AddReward(reward.user, reward.amount, rewardFunctionArgs);
+      emit AddRewardWithIdempotency(
+        reward.user,
+        reward.amount,
+        reward.idempotencyKey,
+        rewardFunctionArgs
+      );
+    } else {
+      emit AddRewardSkipped(reward.user, reward.amount, reward.idempotencyKey);
     }
   }
 
@@ -393,6 +557,12 @@ contract RewardPool is AccessControl, ReentrancyGuard {
     reserveAddress = _reserveAddress;
   }
 
+  function _setRewardFunctionAddress(address _rewardFunctionAddress) internal {
+    if (_rewardFunctionAddress == address(0))
+      revert InvalidRewardFunctionAddress();
+    rewardFunctionAddress = _rewardFunctionAddress;
+  }
+
   /**
    * @dev Sets the protocol fee
    * @param _protocolFee Protocol fee numerator (denominator is 10^18)
@@ -421,6 +591,22 @@ contract RewardPool is AccessControl, ReentrancyGuard {
     address previousReserveAddress = reserveAddress;
     _setReserveAddress(_reserveAddress);
     emit ReserveAddressUpdated(_reserveAddress, previousReserveAddress);
+  }
+
+  /**
+   * @dev Sets the reward function address
+   * @param _rewardFunctionAddress Address of the reward function
+   * @notice Allowed only for address with DEFAULT_ADMIN_ROLE
+   */
+  function setRewardFunctionAddress(
+    address _rewardFunctionAddress
+  ) external onlyRole(DEFAULT_ADMIN_ROLE) {
+    address previousRewardFunctionAddress = rewardFunctionAddress;
+    _setRewardFunctionAddress(_rewardFunctionAddress);
+    emit RewardFunctionAddressUpdated(
+      _rewardFunctionAddress,
+      previousRewardFunctionAddress
+    );
   }
 
   /**

--- a/contracts/RewardPoolFactory.sol
+++ b/contracts/RewardPoolFactory.sol
@@ -21,7 +21,7 @@ contract RewardPoolFactory is
   // Events
   event RewardPoolCreated(
     address indexed poolToken,
-    bytes32 rewardFunctionId,
+    address rewardFunctionAddress,
     address indexed owner,
     address indexed manager,
     uint256 timelock,
@@ -92,14 +92,14 @@ contract RewardPoolFactory is
   /**
    * @dev Creates a new RewardPool contract using minimal proxy pattern
    * @param _poolToken Address of the token used for rewards
-   * @param _rewardFunctionId Bytes32 identifier of the reward function (e.g. git commit hash)
+   * @param _rewardFunctionAddress Address of the reward function
    * @param _manager Address that will have MANAGER_ROLE in the RewardPool
    * @param _timelock Timestamp when manager withdrawals will be allowed
    * @return The address of the newly created RewardPool contract
    */
   function createRewardPool(
     address _poolToken,
-    bytes32 _rewardFunctionId,
+    address _rewardFunctionAddress,
     address _manager,
     uint256 _timelock
   ) external returns (address) {
@@ -110,7 +110,7 @@ contract RewardPoolFactory is
     address clone = implementation.clone();
     RewardPool(payable(clone)).initialize(
       _poolToken,
-      _rewardFunctionId,
+      _rewardFunctionAddress,
       defaultOwner,
       _manager,
       _timelock,
@@ -120,7 +120,7 @@ contract RewardPoolFactory is
 
     emit RewardPoolCreated(
       _poolToken,
-      _rewardFunctionId,
+      _rewardFunctionAddress,
       defaultOwner,
       _manager,
       _timelock,

--- a/tasks/rewardPool.ts
+++ b/tasks/rewardPool.ts
@@ -3,7 +3,7 @@ import { deployContract } from './helpers/deployHelpers'
 
 task('reward-pool:deploy', 'Deploy RewardPool contract')
   .addParam('poolToken', 'Address of the token used for rewards')
-  .addOptionalParam('rewardFunction', 'Identifier of the reward function')
+  .addParam('rewardFunctionAddress', 'Address of the reward function')
   .addOptionalParam('ownerAddress', 'Address to use as owner')
   .addOptionalParam('managerAddress', 'Address that will have MANAGER_ROLE')
   .addOptionalParam(
@@ -27,17 +27,12 @@ task('reward-pool:deploy', 'Deploy RewardPool contract')
 
     const managerAddress = taskArgs.managerAddress || ownerAddress
 
-    const rewardFunctionId = hre.ethers.zeroPadValue(
-      taskArgs.rewardFunction || '0x00',
-      32,
-    )
-
     await deployContract(
       hre,
       'RewardPool',
       [
         taskArgs.poolToken,
-        rewardFunctionId,
+        taskArgs.rewardFunctionAddress,
         ownerAddress,
         managerAddress,
         taskArgs.timelock,

--- a/test/RewardPool.ts
+++ b/test/RewardPool.ts
@@ -1,5 +1,5 @@
 import { expect } from 'chai'
-import { Contract, TransactionReceipt } from 'ethers'
+import { Contract, TransactionReceipt, AbiCoder } from 'ethers'
 import hre from 'hardhat'
 import {
   loadFixture,
@@ -11,10 +11,6 @@ import { HardhatEthersSigner } from '@nomicfoundation/hardhat-ethers/signers'
 
 const CONTRACT_NAME = 'RewardPool'
 const NATIVE_TOKEN_ADDRESS = '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE'
-const MOCK_REWARD_FUNCTION_ID = hre.ethers.zeroPadValue(
-  '0xa1b2c3d4e5f67890abcdef1234567890abcdef12',
-  32,
-)
 const MOCK_REWARD_FUNCTION_ARGS = [1000, 2000]
 const WEEK_IN_SECONDS = 60 * 60 * 24 * 7
 const TIMELOCK = WEEK_IN_SECONDS
@@ -38,16 +34,20 @@ describe(CONTRACT_NAME, function () {
     const MockERC20 = await hre.ethers.getContractFactory('MockERC20')
     const mockERC20 = await MockERC20.deploy('MockERC20', 'MOCK')
 
+    const LinearReward = await hre.ethers.getContractFactory('LinearReward')
+    const linearReward = await LinearReward.deploy()
+
     const RewardPool = await hre.ethers.getContractFactory(CONTRACT_NAME)
 
     const tokenAddress =
       tokenType === 'native'
         ? NATIVE_TOKEN_ADDRESS
         : await mockERC20.getAddress()
+    const rewardFunctionAddress = await linearReward.getAddress()
 
     const implementation = await RewardPool.deploy(
       tokenAddress,
-      MOCK_REWARD_FUNCTION_ID,
+      rewardFunctionAddress,
       owner.address,
       manager.address,
       (await time.latest()) + TIMELOCK,
@@ -72,6 +72,7 @@ describe(CONTRACT_NAME, function () {
       user1,
       user2,
       stranger,
+      rewardFunctionAddress,
     }
   }
 
@@ -115,7 +116,7 @@ describe(CONTRACT_NAME, function () {
   describe('Initialization', function () {
     tokenTypes.forEach(function ({ tokenType, deployFixture }) {
       it(`initializes correclty with ${tokenType} token`, async function () {
-        const { rewardPool, mockERC20, owner, manager } =
+        const { rewardPool, mockERC20, owner, manager, rewardFunctionAddress } =
           await loadFixture(deployFixture)
 
         const expectedTokenAddress =
@@ -127,8 +128,8 @@ describe(CONTRACT_NAME, function () {
         expect(await rewardPool.isNativeToken()).to.equal(
           tokenType === 'native',
         )
-        expect(await rewardPool.rewardFunctionId()).to.equal(
-          MOCK_REWARD_FUNCTION_ID,
+        expect(await rewardPool.rewardFunctionAddress()).to.equal(
+          rewardFunctionAddress,
         )
         expect(
           await rewardPool.hasRole(
@@ -148,13 +149,13 @@ describe(CONTRACT_NAME, function () {
           .to.emit(rewardPool, 'PoolInitialized')
           .withArgs(
             expectedTokenAddress,
-            MOCK_REWARD_FUNCTION_ID,
+            rewardFunctionAddress,
             currentTimelock,
           )
       })
 
       it(`reverts when trying to initialize after deployment with ${tokenType} token`, async function () {
-        const { rewardPool, mockERC20, owner, manager } =
+        const { rewardPool, mockERC20, owner, manager, rewardFunctionAddress } =
           await loadFixture(deployFixture)
 
         const tokenAddress =
@@ -165,7 +166,7 @@ describe(CONTRACT_NAME, function () {
         await expect(
           rewardPool.initialize(
             tokenAddress,
-            MOCK_REWARD_FUNCTION_ID,
+            rewardFunctionAddress,
             owner.address,
             manager.address,
             (await time.latest()) + TIMELOCK,
@@ -1078,6 +1079,416 @@ describe(CONTRACT_NAME, function () {
             rewardAmount,
           )
         })
+      })
+    })
+  })
+
+  describe('KPI management', function () {
+    let rewardPool: Contract
+    let owner: HardhatEthersSigner
+    let user1: HardhatEthersSigner
+    let user2: HardhatEthersSigner
+    let stranger: HardhatEthersSigner
+    let pool: Contract
+    let rewardFunctionAddress: string
+    const mockKpiFunctionId = hre.ethers.keccak256(
+      hre.ethers.toUtf8Bytes('mock-kpi-function'),
+    )
+    const mockStartTime = 1000000
+    const mockEndTime = 2000000
+    const mockRewardPeriodKey = hre.ethers.keccak256(
+      AbiCoder.defaultAbiCoder().encode(
+        ['uint256', 'uint256'],
+        [mockStartTime, mockEndTime],
+      ),
+    )
+    let mockKpis: { referrerAddress: string; kpi: number }[]
+
+    function getIdempotencyKey(
+      user: string,
+      periodStart: number = mockStartTime,
+      periodEnd: number = mockEndTime,
+    ) {
+      return hre.ethers.keccak256(
+        AbiCoder.defaultAbiCoder().encode(
+          ['address', 'uint256', 'uint256'],
+          [user, periodStart, periodEnd],
+        ),
+      )
+    }
+
+    beforeEach(async function () {
+      const deployment = await loadFixture(deployERC20RewardPoolContract)
+      rewardPool = deployment.rewardPool
+      owner = deployment.owner
+      user1 = deployment.user1
+      user2 = deployment.user2
+      stranger = deployment.stranger
+      rewardFunctionAddress = deployment.rewardFunctionAddress
+
+      // Connect with owner
+      pool = rewardPool.connect(owner) as typeof rewardPool
+
+      mockKpis = [
+        {
+          referrerAddress: user1.address,
+          kpi: 100,
+        },
+        {
+          referrerAddress: user2.address,
+          kpi: 200,
+        },
+      ]
+    })
+
+    describe('Add KPI', function () {
+      it('allows owner to add and update kpis', async function () {
+        await expect(
+          pool.addKpis(mockKpis, mockStartTime, mockEndTime, mockKpiFunctionId),
+        )
+          .to.emit(rewardPool, 'AddKpi')
+          .withArgs(
+            user1.address,
+            mockRewardPeriodKey,
+            100,
+            mockStartTime,
+            mockEndTime,
+            mockKpiFunctionId,
+          )
+          .to.emit(rewardPool, 'AddKpi')
+          .withArgs(
+            user2.address,
+            mockRewardPeriodKey,
+            200,
+            mockStartTime,
+            mockEndTime,
+            mockKpiFunctionId,
+          )
+
+        expect(
+          await rewardPool.periodKpis(mockRewardPeriodKey, user1.address),
+        ).to.equal(100)
+        expect(
+          await rewardPool.periodKpis(mockRewardPeriodKey, user2.address),
+        ).to.equal(200)
+
+        expect(await rewardPool.processedPeriods(mockRewardPeriodKey)).to.equal(
+          false,
+        )
+
+        await expect(
+          pool.addKpis(
+            [
+              {
+                referrerAddress: user1.address,
+                kpi: 150,
+              },
+            ],
+            mockStartTime,
+            mockEndTime,
+            mockKpiFunctionId,
+          ),
+        )
+          .to.emit(rewardPool, 'AddKpi')
+          .withArgs(
+            user1.address,
+            mockRewardPeriodKey,
+            150,
+            mockStartTime,
+            mockEndTime,
+            mockKpiFunctionId,
+          )
+
+        expect(
+          await rewardPool.periodKpis(mockRewardPeriodKey, user1.address),
+        ).to.equal(150)
+      })
+
+      it('allows owner to add kpis with zero kpi', async function () {
+        await expect(
+          pool.addKpis(
+            [
+              {
+                referrerAddress: user1.address,
+                kpi: 100,
+              },
+              {
+                referrerAddress: user2.address,
+                kpi: 0,
+              },
+            ],
+            mockStartTime,
+            mockEndTime,
+            mockKpiFunctionId,
+          ),
+        )
+          .to.emit(rewardPool, 'AddKpi')
+          .withArgs(
+            user1.address,
+            mockRewardPeriodKey,
+            100,
+            mockStartTime,
+            mockEndTime,
+            mockKpiFunctionId,
+          )
+          .to.emit(rewardPool, 'AddKpi')
+          .withArgs(
+            user2.address,
+            mockRewardPeriodKey,
+            0,
+            mockStartTime,
+            mockEndTime,
+            mockKpiFunctionId,
+          )
+
+        expect(
+          await rewardPool.periodKpis(mockRewardPeriodKey, user1.address),
+        ).to.equal(100)
+        expect(
+          await rewardPool.periodKpis(mockRewardPeriodKey, user2.address),
+        ).to.equal(0)
+
+        await expect(
+          pool.addKpis(
+            [
+              {
+                referrerAddress: user1.address,
+                kpi: 0,
+              },
+            ],
+            mockStartTime,
+            mockEndTime,
+            mockKpiFunctionId,
+          ),
+        )
+          .to.emit(rewardPool, 'AddKpi')
+          .withArgs(
+            user1.address,
+            mockRewardPeriodKey,
+            0,
+            mockStartTime,
+            mockEndTime,
+            mockKpiFunctionId,
+          )
+
+        expect(
+          await rewardPool.periodKpis(mockRewardPeriodKey, user1.address),
+        ).to.equal(0)
+        expect(
+          await rewardPool.periodKpis(mockRewardPeriodKey, user2.address),
+        ).to.equal(0)
+      })
+
+      it('reverts when kpis are added for zero address', async function () {
+        const kpis = [
+          {
+            referrerAddress: hre.ethers.ZeroAddress,
+            kpi: 100,
+          },
+        ]
+
+        await expect(
+          pool.addKpis(kpis, mockStartTime, mockEndTime, mockKpiFunctionId),
+        ).to.be.revertedWithCustomError(rewardPool, 'ZeroAddressNotAllowed')
+      })
+
+      it('reverts when start time is greater than end time', async function () {
+        await expect(
+          pool.addKpis(mockKpis, mockEndTime, mockStartTime, mockKpiFunctionId),
+        ).to.be.revertedWithCustomError(rewardPool, 'RewardPeriodInvalid')
+      })
+
+      it('reverts if kpi period is already processed', async function () {
+        await pool.addKpis(
+          mockKpis,
+          mockStartTime,
+          mockEndTime,
+          mockKpiFunctionId,
+        )
+
+        await pool.processRewardPeriod(mockStartTime, mockEndTime, 100)
+
+        await expect(
+          pool.addKpis(mockKpis, mockStartTime, mockEndTime, mockKpiFunctionId),
+        ).to.be.revertedWithCustomError(
+          rewardPool,
+          'RewardPeriodAlreadyProcessed',
+        )
+      })
+
+      it('does not allow non-owner to add kpis', async function () {
+        const poolWithStranger = pool.connect(stranger) as typeof rewardPool
+
+        await expect(
+          poolWithStranger.addKpis(
+            mockKpis,
+            mockStartTime,
+            mockEndTime,
+            mockKpiFunctionId,
+          ),
+        ).to.be.revertedWithCustomError(
+          rewardPool,
+          'AccessControlUnauthorizedAccount',
+        )
+      })
+    })
+
+    describe('Process Reward Period', function () {
+      it('allows owner to process reward period and distribute rewards', async function () {
+        await pool.addKpis(
+          mockKpis,
+          mockStartTime,
+          mockEndTime,
+          mockKpiFunctionId,
+        )
+
+        await expect(pool.processRewardPeriod(mockStartTime, mockEndTime, 100))
+          .to.emit(rewardPool, 'RewardPeriodProcessed')
+          .withArgs(mockRewardPeriodKey, mockStartTime, mockEndTime, 100)
+          .to.emit(rewardPool, 'AddRewardWithIdempotency')
+          .withArgs(user1.address, 33, getIdempotencyKey(user1.address), [
+            mockStartTime,
+            mockEndTime,
+          ])
+          .to.emit(rewardPool, 'AddRewardWithIdempotency')
+          .withArgs(user2.address, 66, getIdempotencyKey(user2.address), [
+            mockStartTime,
+            mockEndTime,
+          ])
+
+        expect(await rewardPool.processedPeriods(mockRewardPeriodKey)).to.equal(
+          true,
+        )
+
+        expect(await rewardPool.pendingRewards(user1.address)).to.equal(33)
+        expect(await rewardPool.pendingRewards(user2.address)).to.equal(66)
+      })
+
+      it('handles some users with zero rewards', async function () {
+        await pool.addKpis(
+          [
+            {
+              referrerAddress: user1.address,
+              kpi: 0,
+            },
+            {
+              referrerAddress: user2.address,
+              kpi: 200,
+            },
+          ],
+          mockStartTime,
+          mockEndTime,
+          mockKpiFunctionId,
+        )
+
+        await expect(pool.processRewardPeriod(mockStartTime, mockEndTime, 100))
+          .to.emit(rewardPool, 'RewardPeriodProcessed')
+          .withArgs(mockRewardPeriodKey, mockStartTime, mockEndTime, 100)
+          .to.emit(rewardPool, 'AddRewardWithIdempotency')
+          .withArgs(user2.address, 100, getIdempotencyKey(user2.address), [
+            mockStartTime,
+            mockEndTime,
+          ])
+
+        expect(await rewardPool.pendingRewards(user1.address)).to.equal(0)
+        expect(await rewardPool.pendingRewards(user2.address)).to.equal(100)
+      })
+
+      it('reverts if reward period is already processed', async function () {
+        await pool.addKpis(
+          mockKpis,
+          mockStartTime,
+          mockEndTime,
+          mockKpiFunctionId,
+        )
+
+        await pool.processRewardPeriod(mockStartTime, mockEndTime, 100)
+
+        await expect(
+          pool.processRewardPeriod(mockStartTime, mockEndTime, 100),
+        ).to.be.revertedWithCustomError(
+          rewardPool,
+          'RewardPeriodAlreadyProcessed',
+        )
+      })
+
+      it('reverts if reward period has no users / kpis', async function () {
+        await pool.addKpis(
+          mockKpis,
+          mockStartTime,
+          mockEndTime,
+          mockKpiFunctionId,
+        )
+
+        await pool.addKpis(
+          [
+            {
+              referrerAddress: user1.address,
+              kpi: 0,
+            },
+            {
+              referrerAddress: user2.address,
+              kpi: 0,
+            },
+          ],
+          mockStartTime,
+          mockEndTime,
+          mockKpiFunctionId,
+        )
+        await expect(
+          pool.processRewardPeriod(mockStartTime, mockEndTime, 100),
+        ).to.be.revertedWithCustomError(rewardPool, 'RewardPeriodInvalid')
+      })
+
+      it('does not allow non-owner to process reward period', async function () {
+        const poolWithStranger = pool.connect(stranger) as typeof rewardPool
+
+        await expect(
+          poolWithStranger.processRewardPeriod(mockStartTime, mockEndTime, 100),
+        ).to.be.revertedWithCustomError(
+          rewardPool,
+          'AccessControlUnauthorizedAccount',
+        )
+      })
+    })
+
+    describe('Set Reward Function Address', function () {
+      it('allows owner to set reward function address', async function () {
+        const anotherRewardFunctionAddress =
+          '0x1234567890123456789012345678901234567890'
+        await expect(
+          pool.setRewardFunctionAddress(anotherRewardFunctionAddress),
+        )
+          .to.emit(rewardPool, 'RewardFunctionAddressUpdated')
+          .withArgs(anotherRewardFunctionAddress, rewardFunctionAddress)
+
+        expect(await rewardPool.rewardFunctionAddress()).to.equal(
+          anotherRewardFunctionAddress,
+        )
+      })
+
+      it('reverts if reward function address is zero address', async function () {
+        await expect(
+          pool.setRewardFunctionAddress(hre.ethers.ZeroAddress),
+        ).to.be.revertedWithCustomError(
+          rewardPool,
+          'InvalidRewardFunctionAddress',
+        )
+      })
+
+      it('does not allow non-owner to set reward function address', async function () {
+        const poolWithStranger = pool.connect(stranger) as typeof rewardPool
+        const anotherRewardFunctionAddress =
+          '0x1234567890123456789012345678901234567890'
+
+        await expect(
+          poolWithStranger.setRewardFunctionAddress(
+            anotherRewardFunctionAddress,
+          ),
+        ).to.be.revertedWithCustomError(
+          rewardPool,
+          'AccessControlUnauthorizedAccount',
+        )
       })
     })
   })

--- a/test/RewardPoolFactory.ts
+++ b/test/RewardPoolFactory.ts
@@ -7,10 +7,6 @@ import { HardhatEthersSigner } from '@nomicfoundation/hardhat-ethers/signers'
 const CONTRACT_NAME = 'RewardPoolFactory'
 const IMPLEMENTATION_NAME = 'RewardPool'
 const NATIVE_TOKEN_ADDRESS = '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE'
-const MOCK_REWARD_FUNCTION_ID = hre.ethers.zeroPadValue(
-  '0xa1b2c3d4e5f67890abcdef1234567890abcdef12',
-  32,
-)
 const WEEK_IN_SECONDS = 60 * 60 * 24 * 7
 const TRANSFER_DELAY = WEEK_IN_SECONDS
 const TIMELOCK = WEEK_IN_SECONDS
@@ -20,11 +16,15 @@ describe(CONTRACT_NAME, function () {
     const [deployer, owner, manager, user1, user2, stranger] =
       await hre.ethers.getSigners()
 
+    const LinearReward = await hre.ethers.getContractFactory('LinearReward')
+    const linearReward = await LinearReward.deploy()
+    const rewardFunctionAddress = await linearReward.getAddress()
+
     // Deploy implementation
     const RewardPool = await hre.ethers.getContractFactory(IMPLEMENTATION_NAME)
     const implementation = await RewardPool.deploy(
       NATIVE_TOKEN_ADDRESS,
-      MOCK_REWARD_FUNCTION_ID,
+      rewardFunctionAddress,
       owner.address,
       manager.address,
       (await time.latest()) + TIMELOCK,
@@ -58,6 +58,7 @@ describe(CONTRACT_NAME, function () {
       user1,
       user2,
       stranger,
+      rewardFunctionAddress,
     }
   }
 
@@ -84,6 +85,7 @@ describe(CONTRACT_NAME, function () {
     let owner: HardhatEthersSigner
     let manager: HardhatEthersSigner
     let user1: HardhatEthersSigner
+    let rewardFunctionAddress: string
 
     beforeEach(async function () {
       const deployment = await loadFixture(deployFactoryContract)
@@ -91,17 +93,17 @@ describe(CONTRACT_NAME, function () {
       owner = deployment.owner
       manager = deployment.manager
       user1 = deployment.user1
+      rewardFunctionAddress = deployment.rewardFunctionAddress
     })
 
     it('creates a new RewardPool clone', async function () {
       const poolToken = await hre.ethers.getSigner(user1.address)
-      const rewardFunctionId = MOCK_REWARD_FUNCTION_ID
       const poolManager = user1.address
       const timelock = (await time.latest()) + TIMELOCK
 
       const tx = await factory.createRewardPool(
         poolToken.address,
-        rewardFunctionId,
+        rewardFunctionAddress,
         poolManager,
         timelock,
       )
@@ -118,7 +120,7 @@ describe(CONTRACT_NAME, function () {
         .to.emit(factory, 'RewardPoolCreated')
         .withArgs(
           poolToken.address,
-          rewardFunctionId,
+          rewardFunctionAddress,
           owner.address,
           poolManager,
           timelock,
@@ -133,7 +135,6 @@ describe(CONTRACT_NAME, function () {
       )
 
       expect(await rewardPool.poolToken()).to.equal(poolToken.address)
-      expect(await rewardPool.rewardFunctionId()).to.equal(rewardFunctionId)
       expect(
         await rewardPool.hasRole(
           await rewardPool.DEFAULT_ADMIN_ROLE(),
@@ -158,7 +159,7 @@ describe(CONTRACT_NAME, function () {
       await expect(
         factory.createRewardPool(
           hre.ethers.ZeroAddress,
-          MOCK_REWARD_FUNCTION_ID,
+          rewardFunctionAddress,
           manager.address,
           (await time.latest()) + TIMELOCK,
         ),
@@ -169,7 +170,7 @@ describe(CONTRACT_NAME, function () {
       await expect(
         factory.createRewardPool(
           user1.address,
-          MOCK_REWARD_FUNCTION_ID,
+          rewardFunctionAddress,
           hre.ethers.ZeroAddress,
           (await time.latest()) + TIMELOCK,
         ),
@@ -184,6 +185,8 @@ describe(CONTRACT_NAME, function () {
     let stranger: HardhatEthersSigner
     let factoryWithOwner: Contract
     let factoryWithStranger: Contract
+    let rewardFunctionAddress: string
+
     beforeEach(async function () {
       const deployment = await loadFixture(deployFactoryContract)
       factory = deployment.factory
@@ -192,6 +195,7 @@ describe(CONTRACT_NAME, function () {
       stranger = deployment.stranger
       factoryWithOwner = factory.connect(owner) as typeof factory
       factoryWithStranger = factory.connect(stranger) as typeof factory
+      rewardFunctionAddress = deployment.rewardFunctionAddress
     })
 
     it('initializes with correct default values', async function () {
@@ -301,13 +305,12 @@ describe(CONTRACT_NAME, function () {
 
       // Create a new pool using the same factory instance (not a new deployment)
       const poolToken = user1.address
-      const rewardFunctionId = MOCK_REWARD_FUNCTION_ID
       const poolManager = user1.address
       const timelock = (await time.latest()) + TIMELOCK
 
       const tx = await factory.createRewardPool(
         poolToken,
-        rewardFunctionId,
+        rewardFunctionAddress,
         poolManager,
         timelock,
       )


### PR DESCRIPTION
RewardPool changes:
- updates the constructor and initializer to take a `rewardFunctionAddress` instead of a `rewardFunctionId` which must be an implementation of `IRewardFunction`
- adds an `addKpis` method which can be called with a set of (referrer, kpi) pairs for a reward period (identified by start and end timestamp)
  - performs an upsert of kpis for the period
  - 0 kpis are treated as no kpis (can be used for deletion)
  - only allows adding kpis if a reward period is not already processed and rewards are issued
- adds a `processRewardPeriod` method which can be called with a reward period (start and end timestamp) and a reward amount
  - calls `IRewardFunction`'s `calculateReward` method by collecting all the kpis for the given period and issues rewards
  - marks the period as processed so it doesn't end up issuing rewards again
- adds a `setRewardFunctionAddress` to allow updating `rewardFunctionAddress`
 
RewardPoolFactory changes:
- updates to match the constructor changes in RewardPool