### PR TITLE
fix(RewardPool): prevent 0 address with owner and/or manager

### DIFF
--- a/contracts/RewardPool.sol
+++ b/contracts/RewardPool.sol
@@ -182,6 +182,9 @@ contract RewardPool is AccessControl, ReentrancyGuard {
     if (initialized) revert AlreadyInitialized();
     initialized = true;
 
+    if (_owner == address(0)) revert ZeroAddressNotAllowed(0);
+    if (_manager == address(0)) revert ZeroAddressNotAllowed(1);
+
     _grantRole(DEFAULT_ADMIN_ROLE, _owner);
     _setRoleAdmin(MANAGER_ROLE, DEFAULT_ADMIN_ROLE);
     _grantRole(MANAGER_ROLE, _manager);
@@ -217,6 +220,9 @@ contract RewardPool is AccessControl, ReentrancyGuard {
     address _reserveAddress
   ) {
     initialized = true;
+
+    if (_owner == address(0)) revert ZeroAddressNotAllowed(0);
+    if (_manager == address(0)) revert ZeroAddressNotAllowed(1);
 
     _grantRole(DEFAULT_ADMIN_ROLE, _owner);
     _setRoleAdmin(MANAGER_ROLE, DEFAULT_ADMIN_ROLE);

--- a/test/RewardPool.ts
+++ b/test/RewardPool.ts
@@ -179,6 +179,44 @@ describe(CONTRACT_NAME, function () {
         ).to.be.revertedWithCustomError(rewardPool, 'AlreadyInitialized')
       })
     })
+
+    it('reverts when owner is zero address', async function () {
+      const RewardPool = await hre.ethers.getContractFactory(CONTRACT_NAME)
+      const [deployer] = await hre.ethers.getSigners()
+
+      await expect(
+        RewardPool.deploy(
+          NATIVE_TOKEN_ADDRESS,
+          MOCK_REWARD_FUNCTION_ID,
+          hre.ethers.ZeroAddress, // zero owner
+          deployer.address,
+          (await time.latest()) + TIMELOCK,
+          0,
+          deployer.address,
+        ),
+      )
+        .to.be.revertedWithCustomError(RewardPool, 'ZeroAddressNotAllowed')
+        .withArgs(0)
+    })
+
+    it('reverts when manager is zero address', async function () {
+      const RewardPool = await hre.ethers.getContractFactory(CONTRACT_NAME)
+      const [deployer] = await hre.ethers.getSigners()
+
+      await expect(
+        RewardPool.deploy(
+          NATIVE_TOKEN_ADDRESS,
+          MOCK_REWARD_FUNCTION_ID,
+          deployer.address,
+          hre.ethers.ZeroAddress, // zero manager
+          (await time.latest()) + TIMELOCK,
+          0,
+          deployer.address,
+        ),
+      )
+        .to.be.revertedWithCustomError(RewardPool, 'ZeroAddressNotAllowed')
+        .withArgs(1)
+    })
   })
 
   describe('Deposit', function () {

--- a/test/RewardPool.ts
+++ b/test/RewardPool.ts
@@ -184,10 +184,14 @@ describe(CONTRACT_NAME, function () {
       const RewardPool = await hre.ethers.getContractFactory(CONTRACT_NAME)
       const [deployer] = await hre.ethers.getSigners()
 
+      const LinearReward = await hre.ethers.getContractFactory('LinearReward')
+      const linearReward = await LinearReward.deploy()
+      const rewardFunctionAddress = await linearReward.getAddress()
+
       await expect(
         RewardPool.deploy(
           NATIVE_TOKEN_ADDRESS,
-          MOCK_REWARD_FUNCTION_ID,
+          rewardFunctionAddress,
           hre.ethers.ZeroAddress, // zero owner
           deployer.address,
           (await time.latest()) + TIMELOCK,
@@ -203,10 +207,14 @@ describe(CONTRACT_NAME, function () {
       const RewardPool = await hre.ethers.getContractFactory(CONTRACT_NAME)
       const [deployer] = await hre.ethers.getSigners()
 
+      const LinearReward = await hre.ethers.getContractFactory('LinearReward')
+      const linearReward = await LinearReward.deploy()
+      const rewardFunctionAddress = await linearReward.getAddress()
+
       await expect(
         RewardPool.deploy(
           NATIVE_TOKEN_ADDRESS,
-          MOCK_REWARD_FUNCTION_ID,
+          rewardFunctionAddress,
           deployer.address,
           hre.ethers.ZeroAddress, // zero manager
           (await time.latest()) + TIMELOCK,


### PR DESCRIPTION
In #472 I initially forgot to call `setDefaultOwner` and after upgrading an existing `RewardPoolFactory`, the created reward pool had its owner set to the 0 address.

This prevents it.