### PR TITLE
refactor(contracts): use referrer consistently over user / referrerAddress

### DIFF
--- a/contracts/RewardPool.sol
+++ b/contracts/RewardPool.sol
@@ -39,7 +39,7 @@ contract RewardPool is AccessControl, ReentrancyGuard {
 
   // Data structures
   struct RewardData {
-    address user;
+    address referrer;
     uint256 amount;
     bytes32 idempotencyKey;
   }
@@ -73,22 +73,22 @@ contract RewardPool is AccessControl, ReentrancyGuard {
   event Withdraw(uint256 amount);
   event TimelockExtended(uint256 newTimelock, uint256 previousTimelock);
   event AddReward(
-    address indexed user,
+    address indexed referrer,
     uint256 amount,
     uint256[] rewardFunctionArgs
   );
   event AddRewardWithIdempotency(
-    address indexed user,
+    address indexed referrer,
     uint256 amount,
     bytes32 indexed idempotencyKey,
     uint256[] rewardFunctionArgs
   );
   event AddRewardSkipped(
-    address indexed user,
+    address indexed referrer,
     uint256 amount,
     bytes32 indexed idempotencyKey
   );
-  event ClaimReward(address indexed user, uint256 amount);
+  event ClaimReward(address indexed referrer, uint256 amount);
   event RescueToken(address token, uint256 amount);
   event ProtocolFeeUpdated(uint256 newProtocolFee, uint256 previousProtocolFee);
   event ReserveAddressUpdated(
@@ -96,7 +96,7 @@ contract RewardPool is AccessControl, ReentrancyGuard {
     address previousReserveAddress
   );
   event ProtocolFeeCollected(
-    address indexed user,
+    address indexed referrer,
     uint256 rewardAmount,
     uint256 feeAmount,
     uint256 protocolFee
@@ -106,7 +106,7 @@ contract RewardPool is AccessControl, ReentrancyGuard {
     address previousRewardFunctionAddress
   );
   event KpiUpdated(
-    address indexed user,
+    address indexed referrer,
     bytes32 indexed periodId,
     uint256 amount,
     uint48 periodStart,
@@ -325,13 +325,12 @@ contract RewardPool is AccessControl, ReentrancyGuard {
     if (period.processedAt != 0) revert PeriodAlreadyProcessed(periodId);
 
     for (uint256 i = 0; i < kpis.length; i++) {
-      if (kpis[i].referrerAddress == address(0))
-        revert ZeroAddressNotAllowed(i);
+      if (kpis[i].referrer == address(0)) revert ZeroAddressNotAllowed(i);
 
-      period.kpis.set(kpis[i].referrerAddress, kpis[i].kpi);
+      period.kpis.set(kpis[i].referrer, kpis[i].kpi);
 
       emit KpiUpdated(
-        kpis[i].referrerAddress,
+        kpis[i].referrer,
         periodId,
         kpis[i].kpi,
         periodStart,
@@ -367,9 +366,9 @@ contract RewardPool is AccessControl, ReentrancyGuard {
     );
 
     for (uint256 i = 0; i < period.kpis.length(); i++) {
-      (address user, uint256 kpi) = period.kpis.at(i);
+      (address referrer, uint256 kpi) = period.kpis.at(i);
 
-      kpis[i] = IRewardFunction.Kpi({referrerAddress: user, kpi: kpi});
+      kpis[i] = IRewardFunction.Kpi({referrer: referrer, kpi: kpi});
     }
 
     IRewardFunction.Reward[] memory rewards = IRewardFunction(
@@ -387,14 +386,10 @@ contract RewardPool is AccessControl, ReentrancyGuard {
       if (rewards[i].reward == 0) continue;
 
       RewardData memory rewardData = RewardData({
-        user: rewards[i].referrerAddress,
+        referrer: rewards[i].referrer,
         amount: rewards[i].reward,
         idempotencyKey: keccak256(
-          abi.encode(
-            rewards[i].referrerAddress,
-            periodStart,
-            periodEndExclusive
-          )
+          abi.encode(rewards[i].referrer, periodStart, periodEndExclusive)
         )
       });
 
@@ -418,28 +413,28 @@ contract RewardPool is AccessControl, ReentrancyGuard {
   }
 
   /**
-   * @dev Returns the kpi of a user for a given period
+   * @dev Returns the kpi of a referrer for a given period
    * @param periodStart Start of the reward period (unix timestamp)
    * @param periodEndExclusive End of the reward period (unix timestamp)
-   * @param user Address of the user
+   * @param referrer Address of the referrer
    * @return uint256 kpi
    */
   function getPeriodKpi(
     uint48 periodStart,
     uint48 periodEndExclusive,
-    address user
+    address referrer
   ) external view returns (uint256) {
     bytes32 periodId = _getPeriodId(periodStart, periodEndExclusive);
-    return _periods[periodId].kpis.get(user);
+    return _periods[periodId].kpis.get(referrer);
   }
 
   /**
-   * @dev Returns the users for a given period
+   * @dev Returns the referrers for a given period
    * @param periodStart Start of the reward period (unix timestamp)
    * @param periodEndExclusive End of the reward period (unix timestamp)
-   * @return address[] array of users
+   * @return address[] array of referrers
    */
-  function getPeriodUsers(
+  function getPeriodReferrers(
     uint48 periodStart,
     uint48 periodEndExclusive
   ) external view returns (address[] memory) {
@@ -462,7 +457,7 @@ contract RewardPool is AccessControl, ReentrancyGuard {
   }
 
   /**
-   * @dev Increases amounts available for users to claim with idempotency protection
+   * @dev Increases amounts available for referrers to claim with idempotency protection
    * @param rewards Array of reward items to process
    * @param rewardFunctionArgs Arguments used to calculate rewards
    * @notice Allowed only for address with DEFAULT_ADMIN_ROLE
@@ -481,12 +476,16 @@ contract RewardPool is AccessControl, ReentrancyGuard {
     uint256[] memory rewardFunctionArgs,
     uint32 index
   ) internal returns (bool) {
-    if (reward.user == address(0)) revert ZeroAddressNotAllowed(index);
+    if (reward.referrer == address(0)) revert ZeroAddressNotAllowed(index);
     if (reward.amount == 0) revert RewardAmountMustBeGreaterThanZero(index);
     if (reward.idempotencyKey == bytes32(0)) revert EmptyIdempotencyKey(index);
 
     if (processedIdempotencyKeys[reward.idempotencyKey]) {
-      emit AddRewardSkipped(reward.user, reward.amount, reward.idempotencyKey);
+      emit AddRewardSkipped(
+        reward.referrer,
+        reward.amount,
+        reward.idempotencyKey
+      );
       return false;
     }
 
@@ -501,20 +500,20 @@ contract RewardPool is AccessControl, ReentrancyGuard {
     if (feeAmount > 0) {
       _transferPoolToken(reserveAddress, feeAmount);
       emit ProtocolFeeCollected(
-        reward.user,
+        reward.referrer,
         reward.amount,
         feeAmount,
         protocolFee
       );
     }
 
-    pendingRewards[reward.user] += reward.amount;
+    pendingRewards[reward.referrer] += reward.amount;
     totalPendingRewards += reward.amount;
 
     // Old event for backwards compatibility
-    emit AddReward(reward.user, reward.amount, rewardFunctionArgs);
+    emit AddReward(reward.referrer, reward.amount, rewardFunctionArgs);
     emit AddRewardWithIdempotency(
-      reward.user,
+      reward.referrer,
       reward.amount,
       reward.idempotencyKey,
       rewardFunctionArgs
@@ -535,15 +534,15 @@ contract RewardPool is AccessControl, ReentrancyGuard {
   }
 
   /**
-   * @dev Allows user to claim their rewards
+   * @dev Allows referrer to claim their rewards
    * @param amount Amount to claim
    */
   function claimReward(uint256 amount) external nonReentrant {
     if (amount == 0) revert AmountMustBeGreaterThanZero();
 
-    uint256 userPendingRewards = pendingRewards[msg.sender];
-    if (amount > userPendingRewards)
-      revert InsufficientRewardBalance(amount, userPendingRewards);
+    uint256 referrerPendingRewards = pendingRewards[msg.sender];
+    if (amount > referrerPendingRewards)
+      revert InsufficientRewardBalance(amount, referrerPendingRewards);
 
     uint256 balance = poolBalance();
     if (amount > balance) revert InsufficientPoolBalance(amount, balance);

--- a/contracts/rewardFunctions/IRewardFunction.sol
+++ b/contracts/rewardFunctions/IRewardFunction.sol
@@ -4,12 +4,12 @@ pragma solidity ^0.8.24;
 interface IRewardFunction {
   struct Kpi {
     uint256 kpi;
-    address referrerAddress;
+    address referrer;
   }
 
   struct Reward {
     uint256 reward;
-    address referrerAddress;
+    address referrer;
   }
 
   function calculateReward(

--- a/contracts/rewardFunctions/LinearReward.sol
+++ b/contracts/rewardFunctions/LinearReward.sol
@@ -26,7 +26,7 @@ contract LinearReward is IRewardFunction {
     for (uint256 i = 0; i < kpis.length; i++) {
       rewards[i] = Reward({
         reward: Math.mulDiv(totalRewardAmount, kpis[i].kpi, totalKpi),
-        referrerAddress: kpis[i].referrerAddress
+        referrer: kpis[i].referrer
       });
     }
   }

--- a/contracts/rewardFunctions/SqrtReward.sol
+++ b/contracts/rewardFunctions/SqrtReward.sol
@@ -30,7 +30,7 @@ contract SqrtReward is IRewardFunction {
           Math.sqrt(kpis[i].kpi * 1e6),
           totalSqrtKpi
         ),
-        referrerAddress: kpis[i].referrerAddress
+        referrer: kpis[i].referrer
       });
     }
   }

--- a/test/LinearReward.ts
+++ b/test/LinearReward.ts
@@ -5,7 +5,7 @@ import { Contract } from 'ethers'
 
 interface Kpi {
   kpi: bigint
-  referrerAddress: string
+  referrer: string
 }
 
 describe('LinearReward', function () {
@@ -34,15 +34,15 @@ describe('LinearReward', function () {
       const kpis = [
         {
           kpi: 100n,
-          referrerAddress: user1.address,
+          referrer: user1.address,
         },
         {
           kpi: 200n,
-          referrerAddress: user2.address,
+          referrer: user2.address,
         },
         {
           kpi: 300n,
-          referrerAddress: user3.address,
+          referrer: user3.address,
         },
       ]
       const totalRewardAmount = 600n
@@ -54,18 +54,18 @@ describe('LinearReward', function () {
 
       expect(rewards).to.have.length(3)
       expect(rewards[0].reward).to.equal(100n) // 600 * 100 / 600
-      expect(rewards[0].referrerAddress).to.equal(user1.address)
+      expect(rewards[0].referrer).to.equal(user1.address)
       expect(rewards[1].reward).to.equal(200n) // 600 * 200 / 600
-      expect(rewards[1].referrerAddress).to.equal(user2.address)
+      expect(rewards[1].referrer).to.equal(user2.address)
       expect(rewards[2].reward).to.equal(300n) // 600 * 300 / 600
-      expect(rewards[2].referrerAddress).to.equal(user3.address)
+      expect(rewards[2].referrer).to.equal(user3.address)
     })
 
     it('should handle single KPI', async function () {
       const kpis = [
         {
           kpi: 500n,
-          referrerAddress: user1.address,
+          referrer: user1.address,
         },
       ]
       const totalRewardAmount = 1000n
@@ -77,18 +77,18 @@ describe('LinearReward', function () {
 
       expect(rewards).to.have.length(1)
       expect(rewards[0].reward).to.equal(1000n)
-      expect(rewards[0].referrerAddress).to.equal(user1.address)
+      expect(rewards[0].referrer).to.equal(user1.address)
     })
 
     it('should handle zero total reward amount', async function () {
       const kpis = [
         {
           kpi: 100n,
-          referrerAddress: user1.address,
+          referrer: user1.address,
         },
         {
           kpi: 200n,
-          referrerAddress: user2.address,
+          referrer: user2.address,
         },
       ]
       const totalRewardAmount = 0n
@@ -107,11 +107,11 @@ describe('LinearReward', function () {
       const kpis = [
         {
           kpi: 0n,
-          referrerAddress: user1.address,
+          referrer: user1.address,
         },
         {
           kpi: 100n,
-          referrerAddress: user2.address,
+          referrer: user2.address,
         },
       ]
       const totalRewardAmount = 100n
@@ -130,11 +130,11 @@ describe('LinearReward', function () {
       const kpis = [
         {
           kpi: 1000000n,
-          referrerAddress: user1.address,
+          referrer: user1.address,
         },
         {
           kpi: 2000000n,
-          referrerAddress: user2.address,
+          referrer: user2.address,
         },
       ]
       const totalRewardAmount = 1500000n

--- a/test/RewardPool.ts
+++ b/test/RewardPool.ts
@@ -17,8 +17,11 @@ const TIMELOCK = WEEK_IN_SECONDS
 const MANAGER_CAPITAL = hre.ethers.parseEther('1000')
 
 // Helper function to generate idempotency keys for testing
-function generateTestIdempotencyKey(user: string, nonce: number = 0): string {
-  return hre.ethers.keccak256(hre.ethers.toUtf8Bytes(`${user}-${nonce}`))
+function generateTestIdempotencyKey(
+  referrer: string,
+  nonce: number = 0,
+): string {
+  return hre.ethers.keccak256(hre.ethers.toUtf8Bytes(`${referrer}-${nonce}`))
 }
 
 describe(CONTRACT_NAME, function () {
@@ -380,12 +383,12 @@ describe(CONTRACT_NAME, function () {
       // Prepare reward data
       const rewards = [
         {
-          user: user1.address,
+          referrer: user1.address,
           amount: hre.ethers.parseEther('10'),
           idempotencyKey: generateTestIdempotencyKey(user1.address, 1),
         },
         {
-          user: user2.address,
+          referrer: user2.address,
           amount: hre.ethers.parseEther('20'),
           idempotencyKey: generateTestIdempotencyKey(user2.address, 1),
         },
@@ -433,7 +436,7 @@ describe(CONTRACT_NAME, function () {
     it('allows adding multiple rewards for the same user with different idempotency keys', async function () {
       // First reward
       const firstReward = {
-        user: user1.address,
+        referrer: user1.address,
         amount: hre.ethers.parseEther('10'),
         idempotencyKey: generateTestIdempotencyKey(user1.address, 1),
       }
@@ -441,7 +444,7 @@ describe(CONTRACT_NAME, function () {
 
       // Second reward with different idempotency key
       const secondReward = {
-        user: user1.address,
+        referrer: user1.address,
         amount: hre.ethers.parseEther('15'),
         idempotencyKey: generateTestIdempotencyKey(user1.address, 2),
       }
@@ -457,7 +460,7 @@ describe(CONTRACT_NAME, function () {
 
     it('skips rewards with duplicate idempotency keys', async function () {
       const reward = {
-        user: user1.address,
+        referrer: user1.address,
         amount: hre.ethers.parseEther('10'),
         idempotencyKey: generateTestIdempotencyKey(user1.address, 1),
       }
@@ -489,7 +492,7 @@ describe(CONTRACT_NAME, function () {
 
     it('reverts when zero address is provided as user', async function () {
       const reward = {
-        user: hre.ethers.ZeroAddress,
+        referrer: hre.ethers.ZeroAddress,
         amount: hre.ethers.parseEther('10'),
         idempotencyKey: generateTestIdempotencyKey(hre.ethers.ZeroAddress, 1),
       }
@@ -501,7 +504,7 @@ describe(CONTRACT_NAME, function () {
 
     it('reverts when zero amount is provided', async function () {
       const reward = {
-        user: user1.address,
+        referrer: user1.address,
         amount: 0,
         idempotencyKey: generateTestIdempotencyKey(user1.address, 1),
       }
@@ -516,7 +519,7 @@ describe(CONTRACT_NAME, function () {
 
     it('reverts when empty idempotency key is provided', async function () {
       const reward = {
-        user: user1.address,
+        referrer: user1.address,
         amount: hre.ethers.parseEther('10'),
         idempotencyKey: hre.ethers.ZeroHash,
       }
@@ -531,7 +534,7 @@ describe(CONTRACT_NAME, function () {
       const poolWithStranger = rewardPool.connect(stranger) as typeof rewardPool
 
       const reward = {
-        user: user1.address,
+        referrer: user1.address,
         amount: hre.ethers.parseEther('10'),
         idempotencyKey: generateTestIdempotencyKey(user1.address, 1),
       }
@@ -546,12 +549,12 @@ describe(CONTRACT_NAME, function () {
 
     it('processes mixed batch with new and duplicate idempotency keys', async function () {
       const reward1 = {
-        user: user1.address,
+        referrer: user1.address,
         amount: hre.ethers.parseEther('10'),
         idempotencyKey: generateTestIdempotencyKey(user1.address, 1),
       }
       const reward2 = {
-        user: user2.address,
+        referrer: user2.address,
         amount: hre.ethers.parseEther('20'),
         idempotencyKey: generateTestIdempotencyKey(user2.address, 1),
       }
@@ -561,7 +564,7 @@ describe(CONTRACT_NAME, function () {
 
       // Second batch - mix of new and duplicate
       const reward3 = {
-        user: user1.address,
+        referrer: user1.address,
         amount: hre.ethers.parseEther('15'),
         idempotencyKey: generateTestIdempotencyKey(user1.address, 2), // New key
       }
@@ -634,7 +637,7 @@ describe(CONTRACT_NAME, function () {
 
           // Add rewards
           const reward = {
-            user: user1.address,
+            referrer: user1.address,
             amount: rewardAmount,
             idempotencyKey: generateTestIdempotencyKey(user1.address, 1),
           }
@@ -1007,7 +1010,7 @@ describe(CONTRACT_NAME, function () {
 
           const rewards = [
             {
-              user: user1.address,
+              referrer: user1.address,
               amount: rewardAmount,
               idempotencyKey: hre.ethers.keccak256(
                 hre.ethers.toUtf8Bytes('test-key-1'),
@@ -1064,7 +1067,7 @@ describe(CONTRACT_NAME, function () {
           const idempotencyKey = generateTestIdempotencyKey(user1.address, 1)
           const rewardData = [
             {
-              user: user1.address,
+              referrer: user1.address,
               amount: rewardAmount,
               idempotencyKey: idempotencyKey,
             },
@@ -1102,17 +1105,17 @@ describe(CONTRACT_NAME, function () {
         [mockStartTime, mockEndTime],
       ),
     )
-    let mockKpis: { referrerAddress: string; kpi: number }[]
+    let mockKpis: { referrer: string; kpi: number }[]
 
     function getIdempotencyKey(
-      user: string,
+      referrer: string,
       periodStart: number = mockStartTime,
       periodEnd: number = mockEndTime,
     ) {
       return hre.ethers.keccak256(
         AbiCoder.defaultAbiCoder().encode(
           ['address', 'uint256', 'uint256'],
-          [user, periodStart, periodEnd],
+          [referrer, periodStart, periodEnd],
         ),
       )
     }
@@ -1131,11 +1134,11 @@ describe(CONTRACT_NAME, function () {
 
       mockKpis = [
         {
-          referrerAddress: user1.address,
+          referrer: user1.address,
           kpi: 100,
         },
         {
-          referrerAddress: user2.address,
+          referrer: user2.address,
           kpi: 200,
         },
       ]
@@ -1186,7 +1189,7 @@ describe(CONTRACT_NAME, function () {
         ).to.equal(200)
 
         expect(
-          await rewardPool.getPeriodUsers(mockStartTime, mockEndTime),
+          await rewardPool.getPeriodReferrers(mockStartTime, mockEndTime),
         ).to.deep.equal([user1.address, user2.address])
 
         expect(
@@ -1197,7 +1200,7 @@ describe(CONTRACT_NAME, function () {
           pool.updatePeriodKpis(
             [
               {
-                referrerAddress: user1.address,
+                referrer: user1.address,
                 kpi: 150,
               },
             ],
@@ -1230,11 +1233,11 @@ describe(CONTRACT_NAME, function () {
           pool.updatePeriodKpis(
             [
               {
-                referrerAddress: user1.address,
+                referrer: user1.address,
                 kpi: 100,
               },
               {
-                referrerAddress: user2.address,
+                referrer: user2.address,
                 kpi: 0,
               },
             ],
@@ -1278,14 +1281,14 @@ describe(CONTRACT_NAME, function () {
         ).to.equal(0)
 
         expect(
-          await rewardPool.getPeriodUsers(mockStartTime, mockEndTime),
+          await rewardPool.getPeriodReferrers(mockStartTime, mockEndTime),
         ).to.deep.equal([user1.address, user2.address])
 
         await expect(
           pool.updatePeriodKpis(
             [
               {
-                referrerAddress: user1.address,
+                referrer: user1.address,
                 kpi: 0,
               },
             ],
@@ -1320,14 +1323,14 @@ describe(CONTRACT_NAME, function () {
         ).to.equal(0)
 
         expect(
-          await rewardPool.getPeriodUsers(mockStartTime, mockEndTime),
+          await rewardPool.getPeriodReferrers(mockStartTime, mockEndTime),
         ).to.deep.equal([user1.address, user2.address])
       })
 
       it('reverts when kpis are added for zero address', async function () {
         const kpis = [
           {
-            referrerAddress: hre.ethers.ZeroAddress,
+            referrer: hre.ethers.ZeroAddress,
             kpi: 100,
           },
         ]
@@ -1425,11 +1428,11 @@ describe(CONTRACT_NAME, function () {
         await pool.updatePeriodKpis(
           [
             {
-              referrerAddress: user1.address,
+              referrer: user1.address,
               kpi: 0,
             },
             {
-              referrerAddress: user2.address,
+              referrer: user2.address,
               kpi: 200,
             },
           ],
@@ -1464,7 +1467,7 @@ describe(CONTRACT_NAME, function () {
         await pool.addRewards(
           [
             {
-              user: user1.address,
+              referrer: user1.address,
               amount: 100,
               idempotencyKey,
             },

--- a/test/SqrtReward.ts
+++ b/test/SqrtReward.ts
@@ -5,7 +5,7 @@ import { Contract } from 'ethers'
 
 interface Kpi {
   kpi: bigint
-  referrerAddress: string
+  referrer: string
 }
 
 describe('SqrtReward', function () {
@@ -34,15 +34,15 @@ describe('SqrtReward', function () {
       const kpis = [
         {
           kpi: 100n,
-          referrerAddress: user1.address,
+          referrer: user1.address,
         }, // sqrt(100 * 10^6) = sqrt(100,000,000) = 10,000
         {
           kpi: 400n,
-          referrerAddress: user2.address,
+          referrer: user2.address,
         }, // sqrt(400 * 10^6) = sqrt(400,000,000) = 20,000
         {
           kpi: 900n,
-          referrerAddress: user3.address,
+          referrer: user3.address,
         }, // sqrt(900 * 10^6) = sqrt(900,000,000) = 30,000
       ]
       const totalRewardAmount = 600n
@@ -55,18 +55,18 @@ describe('SqrtReward', function () {
       expect(rewards).to.have.length(3)
       // total sqrt = 10,000 + 20,000 + 30,000 = 60,000
       expect(rewards[0].reward).to.equal(100n) // 600 * 10,000 / 60,000
-      expect(rewards[0].referrerAddress).to.equal(user1.address)
+      expect(rewards[0].referrer).to.equal(user1.address)
       expect(rewards[1].reward).to.equal(200n) // 600 * 20,000 / 60,000
-      expect(rewards[1].referrerAddress).to.equal(user2.address)
+      expect(rewards[1].referrer).to.equal(user2.address)
       expect(rewards[2].reward).to.equal(300n) // 600 * 30,000 / 60,000
-      expect(rewards[2].referrerAddress).to.equal(user3.address)
+      expect(rewards[2].referrer).to.equal(user3.address)
     })
 
     it('should handle single KPI', async function () {
       const kpis = [
         {
           kpi: 400n,
-          referrerAddress: user1.address,
+          referrer: user1.address,
         }, // sqrt(400 * 10^6) = sqrt(400,000,000) = 20,000
       ]
       const totalRewardAmount = 1000n
@@ -78,18 +78,18 @@ describe('SqrtReward', function () {
 
       expect(rewards).to.have.length(1)
       expect(rewards[0].reward).to.equal(1000n) // 1000 * 20,000 / 20,000
-      expect(rewards[0].referrerAddress).to.equal(user1.address)
+      expect(rewards[0].referrer).to.equal(user1.address)
     })
 
     it('should handle zero total reward amount', async function () {
       const kpis = [
         {
           kpi: 100n,
-          referrerAddress: user1.address,
+          referrer: user1.address,
         },
         {
           kpi: 400n,
-          referrerAddress: user2.address,
+          referrer: user2.address,
         },
       ]
       const totalRewardAmount = 0n
@@ -108,11 +108,11 @@ describe('SqrtReward', function () {
       const kpis = [
         {
           kpi: 0n,
-          referrerAddress: user1.address,
+          referrer: user1.address,
         }, // sqrt(0 * 10^6) = sqrt(0) = 0
         {
           kpi: 100n,
-          referrerAddress: user2.address,
+          referrer: user2.address,
         }, // sqrt(100 * 10^6) = sqrt(100,000,000) = 10,000
       ]
       const totalRewardAmount = 100n
@@ -131,15 +131,15 @@ describe('SqrtReward', function () {
       const kpis = [
         {
           kpi: 2n,
-          referrerAddress: user1.address,
+          referrer: user1.address,
         }, // sqrt(2 * 10^6) = sqrt(2,000,000) ≈ 1,414
         {
           kpi: 5n,
-          referrerAddress: user2.address,
+          referrer: user2.address,
         }, // sqrt(5 * 10^6) = sqrt(5,000,000) ≈ 2,236
         {
           kpi: 10n,
-          referrerAddress: user3.address,
+          referrer: user3.address,
         }, // sqrt(10 * 10^6) = sqrt(10,000,000) ≈ 3,162
       ]
       const totalRewardAmount = 60n


### PR DESCRIPTION
Follow up based on https://github.com/divvi-xyz/divvi-protocol/pull/462#discussion_r2311590339 

This updates the RewardPool and related contracts to use `referrer` consistently over `user` and `referrerAddress`.