### PR TITLE
feat(celo-pg-s1): implement stage-weighted rewards with base/bonus pool split

### DIFF
--- a/src/celoPGRewards.test.ts
+++ b/src/celoPGRewards.test.ts
@@ -49,7 +49,10 @@ describe('calculateRewards', () => {
         uniqueWallets: 50,
         gasUsage: 25_000_000_000n, // 25B
         stage: 0,
-        rewardAmount: '176480',
+        sqrtOnlyReward: '176480', // Pure √KPI on full pool
+        baseReward: '141184', // 80% pool share
+        stageBonus: '0', // Stage 0 gets no bonus
+        rewardAmount: '141184', // Total new system reward
       },
       {
         referrerId: '0xstage1',
@@ -58,7 +61,10 @@ describe('calculateRewards', () => {
         uniqueWallets: 150,
         gasUsage: 1_500_000_000n, // 1.5B
         stage: 1,
-        rewardAmount: '43228',
+        sqrtOnlyReward: '43228',
+        baseReward: '34582',
+        stageBonus: '20000', // Stage 1 gets bonus
+        rewardAmount: '54582',
       },
       {
         referrerId: '0xstage2',
@@ -67,7 +73,10 @@ describe('calculateRewards', () => {
         uniqueWallets: 3_000,
         gasUsage: 15_000_000_000n, // 15B
         stage: 2,
-        rewardAmount: '136701',
+        sqrtOnlyReward: '136701',
+        baseReward: '109360',
+        stageBonus: '40000', // Stage 2 gets higher bonus
+        rewardAmount: '149360',
       },
       {
         referrerId: '0xstage3',
@@ -76,7 +85,10 @@ describe('calculateRewards', () => {
         uniqueWallets: 12_000,
         gasUsage: 60_000_000_000n, // 60B
         stage: 3,
-        rewardAmount: '273402',
+        sqrtOnlyReward: '273402',
+        baseReward: '218721',
+        stageBonus: '60000', // Stage 3 gets even higher bonus
+        rewardAmount: '278721',
       },
       {
         referrerId: '0xstage4',
@@ -85,7 +97,10 @@ describe('calculateRewards', () => {
         uniqueWallets: 1_100_000,
         gasUsage: 110_000_000_000n, // 110B
         stage: 4,
-        rewardAmount: '370188',
+        sqrtOnlyReward: '370188',
+        baseReward: '296150',
+        stageBonus: '80000', // Stage 4 gets highest bonus
+        rewardAmount: '376150',
       },
     ])
   })
@@ -121,6 +136,9 @@ describe('calculateRewards', () => {
         uniqueWallets: 1,
         gasUsage: 100n,
         stage: 0,
+        sqrtOnlyReward: '0', // Excluded from all calculations
+        baseReward: '0', // Excluded
+        stageBonus: '0', // Excluded
         rewardAmount: '0', // Excluded
       },
       {
@@ -130,7 +148,10 @@ describe('calculateRewards', () => {
         uniqueWallets: 1,
         gasUsage: 400n,
         stage: 0,
-        rewardAmount: '30000', // Gets all rewards
+        sqrtOnlyReward: '30000', // Pure √KPI would give all
+        baseReward: '24000', // Gets 80% of pool (stage 0 = no bonus)
+        stageBonus: '0', // Stage 0 gets no stage bonus
+        rewardAmount: '24000', // Total: base + bonus
       },
     ])
   })
@@ -160,7 +181,10 @@ describe('calculateRewards', () => {
         uniqueWallets: 1,
         gasUsage: 100n,
         stage: 0,
-        rewardAmount: '1000',
+        sqrtOnlyReward: '1000', // Pure √KPI would give full amount
+        baseReward: '800', // New system: 80% base reward
+        stageBonus: '0', // Stage 0 gets no stage bonus
+        rewardAmount: '800', // Total: 800 + 0
       },
     ])
   })
@@ -180,6 +204,9 @@ describe('calculateRewards', () => {
         uniqueWallets: 1,
         gasUsage: 100n,
         stage: 0,
+        sqrtOnlyReward: '0', // Zero rewards = zero for all fields
+        baseReward: '0',
+        stageBonus: '0',
         rewardAmount: '0',
       },
     ])

--- a/src/celoPGRewards.ts
+++ b/src/celoPGRewards.ts
@@ -26,6 +26,7 @@ export function calculateRewards({
   kpiData,
   rewards,
   excludedReferrers,
+  stageBonusRatio = 0.2, // 20% for stage bonuses, 80% for base rewards
 }: {
   kpiData: KpiRow[]
   rewards: BigNumber
@@ -36,9 +37,15 @@ export function calculateRewards({
       shouldWarn?: boolean
     }
   >
+  stageBonusRatio?: number
 }) {
   const { referrerReferrals, referrerKpis } = getReferrerMetricsFromKpi(kpiData)
 
+  // Split reward pools
+  const baseRewardPool = rewards.times(1 - stageBonusRatio)
+  const stageBonusPool = rewards.times(stageBonusRatio)
+
+  // Calculate base rewards using existing sqrt formula
   const referrerPowerKpis = Object.entries(referrerKpis).reduce(
     (acc, [referrerId, kpi]) => {
       acc[referrerId] = BigNumber(kpi).sqrt()
@@ -49,7 +56,6 @@ export function calculateRewards({
 
   const totalPower = Object.entries(referrerPowerKpis).reduce(
     (sum, [referrerId, value]) => {
-      // exclude referrers in the exclude list
       if (referrerId.toLowerCase() in excludedReferrers) {
         if (excludedReferrers[referrerId.toLowerCase()].shouldWarn) {
           console.warn(
@@ -62,31 +68,72 @@ export function calculateRewards({
         }
         return sum
       }
-
       return sum.plus(value)
     },
     BigNumber(0),
   )
 
-  const rewardsPerReferrer = Object.entries(referrerPowerKpis).map(
-    ([referrerId, powerKpi]) => {
-      const proportion =
-        referrerId.toLowerCase() in excludedReferrers
+  // Calculate stage weights and total stage weight
+  const referrerStages = Object.entries(referrerKpis).reduce(
+    (acc, [referrerId, kpi]) => {
+      acc[referrerId] = calculateStage({
+        uniqueWallets: referrerReferrals[referrerId],
+        gasUsage: kpi,
+      })
+      return acc
+    },
+    {} as Record<string, number>,
+  )
+
+  const totalStageWeight = Object.entries(referrerStages).reduce(
+    (sum, [referrerId, stage]) => {
+      if (referrerId.toLowerCase() in excludedReferrers) {
+        return sum
+      }
+      // Only qualified stages (1+) get stage bonuses. Stage 0 gets weight 0.
+      return sum + stage
+    },
+    0,
+  )
+
+  const rewardsPerReferrer = Object.entries(referrerKpis).map(
+    ([referrerId, kpi]) => {
+      const isExcluded = referrerId.toLowerCase() in excludedReferrers
+      const stage = referrerStages[referrerId]
+
+      // Calculate pure sqrt reward for comparison (full pool, no stage logic)
+      const sqrtOnlyProportion = isExcluded
+        ? BigNumber(0)
+        : referrerPowerKpis[referrerId].div(totalPower)
+      const sqrtOnlyReward = rewards.times(sqrtOnlyProportion)
+
+      // Calculate base reward (e.g. 80% of total pool if stageBonusRatio is 0.2)
+      const baseProportion = isExcluded
+        ? BigNumber(0)
+        : referrerPowerKpis[referrerId].div(totalPower)
+      const baseReward = baseRewardPool.times(baseProportion)
+
+      // Calculate stage bonus (e.g. 20% of total pool if stageBonusRatio is 0.2)
+      // Only qualified stages (1+) get stage bonuses. Stage 0 gets 0.
+      const stageProportion =
+        isExcluded || totalStageWeight === 0 || stage === 0
           ? BigNumber(0)
-          : BigNumber(powerKpi).div(totalPower)
-      const rewardAmount = rewards.times(proportion)
+          : BigNumber(stage).div(totalStageWeight)
+      const stageBonus = stageBonusPool.times(stageProportion)
+
+      const totalReward = baseReward.plus(stageBonus)
 
       return {
         referrerId,
-        kpi: referrerKpis[referrerId],
+        kpi,
         referralCount: referrerReferrals[referrerId],
         uniqueWallets: referrerReferrals[referrerId],
-        gasUsage: referrerKpis[referrerId],
-        stage: calculateStage({
-          uniqueWallets: referrerReferrals[referrerId],
-          gasUsage: referrerKpis[referrerId],
-        }),
-        rewardAmount: rewardAmount.toFixed(0, BigNumber.ROUND_DOWN),
+        gasUsage: kpi,
+        stage,
+        sqrtOnlyReward: sqrtOnlyReward.toFixed(0, BigNumber.ROUND_DOWN),
+        baseReward: baseReward.toFixed(0, BigNumber.ROUND_DOWN),
+        stageBonus: stageBonus.toFixed(0, BigNumber.ROUND_DOWN),
+        rewardAmount: totalReward.toFixed(0, BigNumber.ROUND_DOWN),
       }
     },
   )


### PR DESCRIPTION
Our current square root proportional system is already pretty fair - it prevents whales from completely dominating rewards. But we're experimenting with adding stage-based incentives to encourage more participation and growth.

### What was considered

I explored a few approaches:

**Option 1 (Stage Multiplier)**: Give higher stages a direct KPI multiplier
- Simple but creates disproportionate advantages
- Could make the rich-get-richer problem worse

**Option 2 (Split Pool)**: Reserve part of rewards for stage bonuses ← **I chose this**
- Keeps 80% merit-based (existing square root proportional fairness)
- Adds 20% stage bonuses that reward progression
- More balanced - doesn't completely change the game

### Why 80/20 feels right

- Stage 0 participants don't get stage bonus rewards
- Qualified participants get meaningful stage bonuses
- Top performers still dominate, but the gap narrows slightly
- Easy to tune if we got the balance wrong

### Still experimenting

This is a first attempt at stage weighting. The 20% allocation is configurable, so we can adjust based on how it plays out. Trying to reward growth without breaking the fairness we already have.

Part of ENG-602