### PR TITLE
feat: update scripts to support on-chain reward calculation

### DIFF
--- a/.github/workflows/calculate-and-upload-KPIs.yaml
+++ b/.github/workflows/calculate-and-upload-KPIs.yaml
@@ -40,6 +40,7 @@ jobs:
             --calculation-timestamp ${{ github.event.inputs.timestamp }} \
             --protocols ${{ github.event.inputs.protocols }} \
             --redis-connection ${{ secrets.REDIS_CONNECTION }}
+            --kpi-function-id ${{ github.sha }}
       - name: Notify Slack on Failure
         if: ${{ failure() || cancelled() }}
         uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1

--- a/abis/RewardFunction.ts
+++ b/abis/RewardFunction.ts
@@ -1,0 +1,50 @@
+export const rewardFunctionAbi = [
+  {
+    inputs: [
+      {
+        components: [
+          {
+            internalType: 'uint256',
+            name: 'kpi',
+            type: 'uint256',
+          },
+          {
+            internalType: 'address',
+            name: 'referrer',
+            type: 'address',
+          },
+        ],
+        internalType: 'struct IRewardFunction.Kpi[]',
+        name: 'kpis',
+        type: 'tuple[]',
+      },
+      {
+        internalType: 'uint256',
+        name: 'totalRewardAmount',
+        type: 'uint256',
+      },
+    ],
+    name: 'calculateReward',
+    outputs: [
+      {
+        components: [
+          {
+            internalType: 'uint256',
+            name: 'reward',
+            type: 'uint256',
+          },
+          {
+            internalType: 'address',
+            name: 'referrer',
+            type: 'address',
+          },
+        ],
+        internalType: 'struct IRewardFunction.Reward[]',
+        name: '',
+        type: 'tuple[]',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+] as const

--- a/abis/RewardPoolWithKpi.ts
+++ b/abis/RewardPoolWithKpi.ts
@@ -1,0 +1,1391 @@
+export const rewardPoolWithKpiAbi = [
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: '_poolToken',
+        type: 'address',
+      },
+      {
+        internalType: 'address',
+        name: '_rewardFunctionAddress',
+        type: 'address',
+      },
+      {
+        internalType: 'address',
+        name: '_owner',
+        type: 'address',
+      },
+      {
+        internalType: 'address',
+        name: '_manager',
+        type: 'address',
+      },
+      {
+        internalType: 'uint256',
+        name: '_timelock',
+        type: 'uint256',
+      },
+      {
+        internalType: 'uint256',
+        name: '_protocolFee',
+        type: 'uint256',
+      },
+      {
+        internalType: 'address',
+        name: '_reserveAddress',
+        type: 'address',
+      },
+    ],
+    stateMutability: 'nonpayable',
+    type: 'constructor',
+  },
+  {
+    inputs: [],
+    name: 'AccessControlBadConfirmation',
+    type: 'error',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: 'account',
+        type: 'address',
+      },
+      {
+        internalType: 'bytes32',
+        name: 'neededRole',
+        type: 'bytes32',
+      },
+    ],
+    name: 'AccessControlUnauthorizedAccount',
+    type: 'error',
+  },
+  {
+    inputs: [],
+    name: 'AlreadyInitialized',
+    type: 'error',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'uint256',
+        name: 'expected',
+        type: 'uint256',
+      },
+      {
+        internalType: 'uint256',
+        name: 'received',
+        type: 'uint256',
+      },
+    ],
+    name: 'AmountMismatch',
+    type: 'error',
+  },
+  {
+    inputs: [],
+    name: 'AmountMustBeGreaterThanZero',
+    type: 'error',
+  },
+  {
+    inputs: [],
+    name: 'CannotRescuePoolToken',
+    type: 'error',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'uint256',
+        name: 'index',
+        type: 'uint256',
+      },
+    ],
+    name: 'EmptyIdempotencyKey',
+    type: 'error',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'bytes32',
+        name: 'key',
+        type: 'bytes32',
+      },
+    ],
+    name: 'EnumerableMapNonexistentKey',
+    type: 'error',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'uint256',
+        name: 'requested',
+        type: 'uint256',
+      },
+      {
+        internalType: 'uint256',
+        name: 'available',
+        type: 'uint256',
+      },
+    ],
+    name: 'InsufficientPoolBalance',
+    type: 'error',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'uint256',
+        name: 'requested',
+        type: 'uint256',
+      },
+      {
+        internalType: 'uint256',
+        name: 'available',
+        type: 'uint256',
+      },
+    ],
+    name: 'InsufficientRewardBalance',
+    type: 'error',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'uint48',
+        name: 'periodStart',
+        type: 'uint48',
+      },
+      {
+        internalType: 'uint48',
+        name: 'periodEndExclusive',
+        type: 'uint48',
+      },
+    ],
+    name: 'InvalidPeriod',
+    type: 'error',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'uint256',
+        name: 'fee',
+        type: 'uint256',
+      },
+    ],
+    name: 'InvalidProtocolFee',
+    type: 'error',
+  },
+  {
+    inputs: [],
+    name: 'InvalidReserveAddress',
+    type: 'error',
+  },
+  {
+    inputs: [],
+    name: 'InvalidRewardFunctionAddress',
+    type: 'error',
+  },
+  {
+    inputs: [],
+    name: 'NativeTokenNotAccepted',
+    type: 'error',
+  },
+  {
+    inputs: [],
+    name: 'NativeTransferFailed',
+    type: 'error',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'bytes32',
+        name: 'periodId',
+        type: 'bytes32',
+      },
+    ],
+    name: 'PeriodAlreadyProcessed',
+    type: 'error',
+  },
+  {
+    inputs: [],
+    name: 'ReentrancyGuardReentrantCall',
+    type: 'error',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'uint256',
+        name: 'index',
+        type: 'uint256',
+      },
+    ],
+    name: 'RewardAmountMustBeGreaterThanZero',
+    type: 'error',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: 'token',
+        type: 'address',
+      },
+    ],
+    name: 'SafeERC20FailedOperation',
+    type: 'error',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'uint256',
+        name: 'proposedTimelock',
+        type: 'uint256',
+      },
+      {
+        internalType: 'uint256',
+        name: 'currentTimelock',
+        type: 'uint256',
+      },
+    ],
+    name: 'TimelockMustBeGreaterThanCurrent',
+    type: 'error',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'uint256',
+        name: 'proposedTimelock',
+        type: 'uint256',
+      },
+      {
+        internalType: 'uint256',
+        name: 'currentBlockNumber',
+        type: 'uint256',
+      },
+    ],
+    name: 'TimelockMustBeInTheFuture',
+    type: 'error',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'uint256',
+        name: 'currentBlockNumber',
+        type: 'uint256',
+      },
+      {
+        internalType: 'uint256',
+        name: 'requiredBlokcNumber',
+        type: 'uint256',
+      },
+    ],
+    name: 'TimelockNotExpired',
+    type: 'error',
+  },
+  {
+    inputs: [],
+    name: 'UseDepositFunction',
+    type: 'error',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'uint256',
+        name: 'index',
+        type: 'uint256',
+      },
+    ],
+    name: 'ZeroAddressNotAllowed',
+    type: 'error',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'referrer',
+        type: 'address',
+      },
+      {
+        indexed: false,
+        internalType: 'uint256',
+        name: 'amount',
+        type: 'uint256',
+      },
+      {
+        indexed: false,
+        internalType: 'uint256[]',
+        name: 'rewardFunctionArgs',
+        type: 'uint256[]',
+      },
+    ],
+    name: 'AddReward',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'referrer',
+        type: 'address',
+      },
+      {
+        indexed: false,
+        internalType: 'uint256',
+        name: 'amount',
+        type: 'uint256',
+      },
+      {
+        indexed: true,
+        internalType: 'bytes32',
+        name: 'idempotencyKey',
+        type: 'bytes32',
+      },
+    ],
+    name: 'AddRewardSkipped',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'referrer',
+        type: 'address',
+      },
+      {
+        indexed: false,
+        internalType: 'uint256',
+        name: 'amount',
+        type: 'uint256',
+      },
+      {
+        indexed: true,
+        internalType: 'bytes32',
+        name: 'idempotencyKey',
+        type: 'bytes32',
+      },
+      {
+        indexed: false,
+        internalType: 'uint256[]',
+        name: 'rewardFunctionArgs',
+        type: 'uint256[]',
+      },
+    ],
+    name: 'AddRewardWithIdempotency',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'referrer',
+        type: 'address',
+      },
+      {
+        indexed: false,
+        internalType: 'uint256',
+        name: 'amount',
+        type: 'uint256',
+      },
+    ],
+    name: 'ClaimReward',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: false,
+        internalType: 'uint256',
+        name: 'amount',
+        type: 'uint256',
+      },
+    ],
+    name: 'Deposit',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'referrer',
+        type: 'address',
+      },
+      {
+        indexed: true,
+        internalType: 'bytes32',
+        name: 'periodId',
+        type: 'bytes32',
+      },
+      {
+        indexed: false,
+        internalType: 'uint256',
+        name: 'amount',
+        type: 'uint256',
+      },
+      {
+        indexed: false,
+        internalType: 'uint48',
+        name: 'periodStart',
+        type: 'uint48',
+      },
+      {
+        indexed: false,
+        internalType: 'uint48',
+        name: 'periodEndExclusive',
+        type: 'uint48',
+      },
+      {
+        indexed: false,
+        internalType: 'bytes32',
+        name: 'kpiFunctionId',
+        type: 'bytes32',
+      },
+    ],
+    name: 'KpiUpdated',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: 'bytes32',
+        name: 'periodId',
+        type: 'bytes32',
+      },
+      {
+        indexed: false,
+        internalType: 'uint48',
+        name: 'periodStart',
+        type: 'uint48',
+      },
+      {
+        indexed: false,
+        internalType: 'uint48',
+        name: 'periodEndExclusive',
+        type: 'uint48',
+      },
+      {
+        indexed: false,
+        internalType: 'uint256',
+        name: 'totalRewardAmount',
+        type: 'uint256',
+      },
+      {
+        indexed: false,
+        internalType: 'uint256',
+        name: 'totalIssuedRewardAmount',
+        type: 'uint256',
+      },
+      {
+        indexed: false,
+        internalType: 'uint256',
+        name: 'numUsersRewarded',
+        type: 'uint256',
+      },
+    ],
+    name: 'PeriodProcessed',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'poolToken',
+        type: 'address',
+      },
+      {
+        indexed: false,
+        internalType: 'address',
+        name: 'rewardFunctionAddress',
+        type: 'address',
+      },
+      {
+        indexed: false,
+        internalType: 'uint256',
+        name: 'timelock',
+        type: 'uint256',
+      },
+    ],
+    name: 'PoolInitialized',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'referrer',
+        type: 'address',
+      },
+      {
+        indexed: false,
+        internalType: 'uint256',
+        name: 'rewardAmount',
+        type: 'uint256',
+      },
+      {
+        indexed: false,
+        internalType: 'uint256',
+        name: 'feeAmount',
+        type: 'uint256',
+      },
+      {
+        indexed: false,
+        internalType: 'uint256',
+        name: 'protocolFee',
+        type: 'uint256',
+      },
+    ],
+    name: 'ProtocolFeeCollected',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: false,
+        internalType: 'uint256',
+        name: 'newProtocolFee',
+        type: 'uint256',
+      },
+      {
+        indexed: false,
+        internalType: 'uint256',
+        name: 'previousProtocolFee',
+        type: 'uint256',
+      },
+    ],
+    name: 'ProtocolFeeUpdated',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: false,
+        internalType: 'address',
+        name: 'token',
+        type: 'address',
+      },
+      {
+        indexed: false,
+        internalType: 'uint256',
+        name: 'amount',
+        type: 'uint256',
+      },
+    ],
+    name: 'RescueToken',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: false,
+        internalType: 'address',
+        name: 'newReserveAddress',
+        type: 'address',
+      },
+      {
+        indexed: false,
+        internalType: 'address',
+        name: 'previousReserveAddress',
+        type: 'address',
+      },
+    ],
+    name: 'ReserveAddressUpdated',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: false,
+        internalType: 'address',
+        name: 'newRewardFunctionAddress',
+        type: 'address',
+      },
+      {
+        indexed: false,
+        internalType: 'address',
+        name: 'previousRewardFunctionAddress',
+        type: 'address',
+      },
+    ],
+    name: 'RewardFunctionAddressUpdated',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: 'bytes32',
+        name: 'role',
+        type: 'bytes32',
+      },
+      {
+        indexed: true,
+        internalType: 'bytes32',
+        name: 'previousAdminRole',
+        type: 'bytes32',
+      },
+      {
+        indexed: true,
+        internalType: 'bytes32',
+        name: 'newAdminRole',
+        type: 'bytes32',
+      },
+    ],
+    name: 'RoleAdminChanged',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: 'bytes32',
+        name: 'role',
+        type: 'bytes32',
+      },
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'account',
+        type: 'address',
+      },
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'sender',
+        type: 'address',
+      },
+    ],
+    name: 'RoleGranted',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: 'bytes32',
+        name: 'role',
+        type: 'bytes32',
+      },
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'account',
+        type: 'address',
+      },
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'sender',
+        type: 'address',
+      },
+    ],
+    name: 'RoleRevoked',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: false,
+        internalType: 'uint256',
+        name: 'newTimelock',
+        type: 'uint256',
+      },
+      {
+        indexed: false,
+        internalType: 'uint256',
+        name: 'previousTimelock',
+        type: 'uint256',
+      },
+    ],
+    name: 'TimelockExtended',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: false,
+        internalType: 'uint256',
+        name: 'amount',
+        type: 'uint256',
+      },
+    ],
+    name: 'Withdraw',
+    type: 'event',
+  },
+  {
+    inputs: [],
+    name: 'DEFAULT_ADMIN_ROLE',
+    outputs: [
+      {
+        internalType: 'bytes32',
+        name: '',
+        type: 'bytes32',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'FEE_DENOMINATOR',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'MANAGER_ROLE',
+    outputs: [
+      {
+        internalType: 'bytes32',
+        name: '',
+        type: 'bytes32',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'NATIVE_TOKEN_ADDRESS',
+    outputs: [
+      {
+        internalType: 'address',
+        name: '',
+        type: 'address',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        components: [
+          {
+            internalType: 'address',
+            name: 'referrer',
+            type: 'address',
+          },
+          {
+            internalType: 'uint256',
+            name: 'amount',
+            type: 'uint256',
+          },
+          {
+            internalType: 'bytes32',
+            name: 'idempotencyKey',
+            type: 'bytes32',
+          },
+        ],
+        internalType: 'struct RewardPool.RewardData[]',
+        name: 'rewards',
+        type: 'tuple[]',
+      },
+      {
+        internalType: 'uint256[]',
+        name: 'rewardFunctionArgs',
+        type: 'uint256[]',
+      },
+    ],
+    name: 'addRewards',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'uint256',
+        name: 'amount',
+        type: 'uint256',
+      },
+    ],
+    name: 'claimReward',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'uint256',
+        name: 'amount',
+        type: 'uint256',
+      },
+    ],
+    name: 'deposit',
+    outputs: [],
+    stateMutability: 'payable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'uint256',
+        name: 'timestamp',
+        type: 'uint256',
+      },
+    ],
+    name: 'extendTimelock',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'uint48',
+        name: 'periodStart',
+        type: 'uint48',
+      },
+      {
+        internalType: 'uint48',
+        name: 'periodEndExclusive',
+        type: 'uint48',
+      },
+      {
+        internalType: 'address',
+        name: 'referrer',
+        type: 'address',
+      },
+    ],
+    name: 'getPeriodKpi',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'uint48',
+        name: 'periodStart',
+        type: 'uint48',
+      },
+      {
+        internalType: 'uint48',
+        name: 'periodEndExclusive',
+        type: 'uint48',
+      },
+    ],
+    name: 'getPeriodReferrers',
+    outputs: [
+      {
+        internalType: 'address[]',
+        name: '',
+        type: 'address[]',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'bytes32',
+        name: 'role',
+        type: 'bytes32',
+      },
+    ],
+    name: 'getRoleAdmin',
+    outputs: [
+      {
+        internalType: 'bytes32',
+        name: '',
+        type: 'bytes32',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'bytes32',
+        name: 'role',
+        type: 'bytes32',
+      },
+      {
+        internalType: 'address',
+        name: 'account',
+        type: 'address',
+      },
+    ],
+    name: 'grantRole',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'bytes32',
+        name: 'role',
+        type: 'bytes32',
+      },
+      {
+        internalType: 'address',
+        name: 'account',
+        type: 'address',
+      },
+    ],
+    name: 'hasRole',
+    outputs: [
+      {
+        internalType: 'bool',
+        name: '',
+        type: 'bool',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: '_poolToken',
+        type: 'address',
+      },
+      {
+        internalType: 'address',
+        name: '_rewardFunctionAddress',
+        type: 'address',
+      },
+      {
+        internalType: 'address',
+        name: '_owner',
+        type: 'address',
+      },
+      {
+        internalType: 'address',
+        name: '_manager',
+        type: 'address',
+      },
+      {
+        internalType: 'uint256',
+        name: '_timelock',
+        type: 'uint256',
+      },
+      {
+        internalType: 'uint256',
+        name: '_protocolFee',
+        type: 'uint256',
+      },
+      {
+        internalType: 'address',
+        name: '_reserveAddress',
+        type: 'address',
+      },
+    ],
+    name: 'initialize',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'bytes32',
+        name: 'idempotencyKey',
+        type: 'bytes32',
+      },
+    ],
+    name: 'isIdempotencyKeyProcessed',
+    outputs: [
+      {
+        internalType: 'bool',
+        name: '',
+        type: 'bool',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'isNativeToken',
+    outputs: [
+      {
+        internalType: 'bool',
+        name: '',
+        type: 'bool',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'uint48',
+        name: 'periodStart',
+        type: 'uint48',
+      },
+      {
+        internalType: 'uint48',
+        name: 'periodEndExclusive',
+        type: 'uint48',
+      },
+    ],
+    name: 'isPeriodProcessed',
+    outputs: [
+      {
+        internalType: 'bool',
+        name: '',
+        type: 'bool',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: '',
+        type: 'address',
+      },
+    ],
+    name: 'pendingRewards',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'poolBalance',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'poolToken',
+    outputs: [
+      {
+        internalType: 'address',
+        name: '',
+        type: 'address',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'uint48',
+        name: 'periodStart',
+        type: 'uint48',
+      },
+      {
+        internalType: 'uint48',
+        name: 'periodEndExclusive',
+        type: 'uint48',
+      },
+      {
+        internalType: 'uint256',
+        name: 'totalRewardAmount',
+        type: 'uint256',
+      },
+    ],
+    name: 'processPeriod',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'bytes32',
+        name: '',
+        type: 'bytes32',
+      },
+    ],
+    name: 'processedIdempotencyKeys',
+    outputs: [
+      {
+        internalType: 'bool',
+        name: '',
+        type: 'bool',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'protocolFee',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'bytes32',
+        name: 'role',
+        type: 'bytes32',
+      },
+      {
+        internalType: 'address',
+        name: 'callerConfirmation',
+        type: 'address',
+      },
+    ],
+    name: 'renounceRole',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: 'rescuedToken',
+        type: 'address',
+      },
+    ],
+    name: 'rescueToken',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'reserveAddress',
+    outputs: [
+      {
+        internalType: 'address',
+        name: '',
+        type: 'address',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'bytes32',
+        name: 'role',
+        type: 'bytes32',
+      },
+      {
+        internalType: 'address',
+        name: 'account',
+        type: 'address',
+      },
+    ],
+    name: 'revokeRole',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'rewardFunctionAddress',
+    outputs: [
+      {
+        internalType: 'address',
+        name: '',
+        type: 'address',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'uint256',
+        name: '_protocolFee',
+        type: 'uint256',
+      },
+    ],
+    name: 'setProtocolFee',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: '_reserveAddress',
+        type: 'address',
+      },
+    ],
+    name: 'setReserveAddress',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: '_rewardFunctionAddress',
+        type: 'address',
+      },
+    ],
+    name: 'setRewardFunctionAddress',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'bytes4',
+        name: 'interfaceId',
+        type: 'bytes4',
+      },
+    ],
+    name: 'supportsInterface',
+    outputs: [
+      {
+        internalType: 'bool',
+        name: '',
+        type: 'bool',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'timelock',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'totalPendingRewards',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        components: [
+          {
+            internalType: 'uint256',
+            name: 'kpi',
+            type: 'uint256',
+          },
+          {
+            internalType: 'address',
+            name: 'referrer',
+            type: 'address',
+          },
+        ],
+        internalType: 'struct IRewardFunction.Kpi[]',
+        name: 'kpis',
+        type: 'tuple[]',
+      },
+      {
+        internalType: 'uint48',
+        name: 'periodStart',
+        type: 'uint48',
+      },
+      {
+        internalType: 'uint48',
+        name: 'periodEndExclusive',
+        type: 'uint48',
+      },
+      {
+        internalType: 'bytes32',
+        name: 'kpiFunctionId',
+        type: 'bytes32',
+      },
+    ],
+    name: 'updatePeriodKpis',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'uint256',
+        name: 'amount',
+        type: 'uint256',
+      },
+    ],
+    name: 'withdraw',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    stateMutability: 'payable',
+    type: 'receive',
+  },
+] as const

--- a/scripts/createRewardPoolWithKpiTxAndSimulateRewards.ts
+++ b/scripts/createRewardPoolWithKpiTxAndSimulateRewards.ts
@@ -1,0 +1,166 @@
+import yargs from 'yargs'
+import { createUpdateKpiAndProcessRewardsSafeTransactionJSON } from './utils/createSafeTransactionsBatch'
+import { ResultDirectory } from '../src/resultDirectory'
+import {
+  getDivviRewardsExcludedReferrers,
+  ExcludedReferrers,
+} from './utils/divviRewardsExcludedReferrers'
+import fs from 'fs'
+import { parse } from 'csv-parse/sync'
+import { protocols } from './types'
+import { campaigns } from '../src/campaigns'
+import { getReferrerMetricsFromKpi } from './calculateRewards/getReferrerMetricsFromKpi'
+import { getViemPublicClient } from './utils'
+import { rewardFunctionAbi } from '../abis/RewardFunction'
+import { rewardPoolWithKpiAbi } from '../abis/RewardPoolWithKpi'
+
+function parseArgs() {
+  const args = yargs
+    .option('protocol', {
+      description: 'the protocol to calculate rewards for',
+      type: 'string',
+      demandOption: true,
+      choices: protocols,
+    })
+    .option('datadir', {
+      description: 'the directory to store the results',
+      type: 'string',
+      default: 'rewards',
+    })
+    .option('start-timestamp', {
+      alias: 's',
+      description: 'start timestamp',
+      type: 'string',
+      demandOption: true,
+    })
+    .option('end-timestamp', {
+      alias: 'e',
+      description: 'end timestamp',
+      type: 'string',
+      demandOption: true,
+    })
+    .option('reward-amount', {
+      alias: 'r',
+      description: 'the reward amount for this time period in smallest units',
+      type: 'string',
+      demandOption: true,
+    })
+    .option('kpi-function-id', {
+      alias: 'k',
+      description: 'the kpi function id (e.g., github commit hash)',
+      type: 'string',
+      demandOption: true,
+    })
+    .option('excluded-referrers-csv', {
+      alias: 'x',
+      description: 'the excluded referrers for this time period in CSV format',
+      type: 'string',
+    })
+    .strict()
+    .parseSync()
+
+  const excludedReferrers: Record<
+    string,
+    { referrerId: string; shouldWarn?: boolean }
+  > = !args['excluded-referrers-csv']
+    ? {}
+    : parse(fs.readFileSync(args['excluded-referrers-csv'], 'utf8'), {
+        columns: true,
+        skip_empty_lines: true,
+        trim: true,
+      }).reduce((acc: ExcludedReferrers, row: { referrerId: string }) => {
+        const address = row['referrerId'].toLowerCase()
+        acc[address] = {
+          referrerId: address,
+          shouldWarn: false,
+        }
+        return acc
+      }, {} as ExcludedReferrers)
+
+  return {
+    resultDirectory: new ResultDirectory({
+      datadir: args.datadir,
+      name: args.protocol,
+      startTimestamp: new Date(args['start-timestamp']),
+      endTimestampExclusive: new Date(args['end-timestamp']),
+    }),
+    startTimestamp: args['start-timestamp'],
+    endTimestampExclusive: args['end-timestamp'],
+    rewardAmount: args['reward-amount'],
+    excludedReferrers,
+    protocol: args.protocol,
+    kpiFunctionId: args['kpi-function-id'],
+  }
+}
+
+export async function main(args: ReturnType<typeof parseArgs>) {
+  const startTimestamp = new Date(args.startTimestamp)
+  const endTimestampExclusive = new Date(args.endTimestampExclusive)
+  const resultDirectory = args.resultDirectory
+  const rewardAmount = args.rewardAmount
+  const kpiData = await resultDirectory.readKpi()
+  const campaign = campaigns.find((c) => c.protocol === args.protocol)
+  if (!campaign) {
+    throw new Error(`Campaign ${args.protocol} not found`)
+  }
+  const rewardPoolAddress = campaign.rewardsPoolAddress
+
+  let excludedReferrers = await getDivviRewardsExcludedReferrers()
+  if (
+    args.excludedReferrers &&
+    Object.keys(args.excludedReferrers).length > 0
+  ) {
+    excludedReferrers = { ...excludedReferrers, ...args.excludedReferrers }
+  }
+
+  await resultDirectory.writeExcludeList(Object.values(excludedReferrers))
+
+  // group kpis by referrer and remove excluded referrers
+  const { referrerReferrals, referrerKpis } = getReferrerMetricsFromKpi(kpiData)
+  const kpis = Object.entries(referrerKpis)
+    .filter(([referrerId]) => !(referrerId.toLowerCase() in excludedReferrers))
+    .map(([referrerId, kpi]) => ({
+      kpi,
+      referrer: referrerId as `0x${string}`,
+    }))
+
+  createUpdateKpiAndProcessRewardsSafeTransactionJSON({
+    filePath: resultDirectory.safeTransactionsFilePath,
+    rewardPoolAddress,
+    kpis,
+    startTimestamp,
+    endTimestampExclusive,
+    kpiFunctionId: args.kpiFunctionId,
+    rewardAmount: BigInt(rewardAmount),
+  })
+
+  // get the reward function address from the reward pool contract and use it to simulate the rewards calculation
+  const publicClient = getViemPublicClient(campaign.networkId)
+  const rewardFunctionAddress = await publicClient.readContract({
+    address: rewardPoolAddress,
+    abi: rewardPoolWithKpiAbi,
+    functionName: 'rewardFunctionAddress',
+  })
+  const rewards = await publicClient.readContract({
+    address: rewardFunctionAddress,
+    abi: rewardFunctionAbi,
+    functionName: 'calculateReward',
+    args: [kpis, BigInt(rewardAmount)],
+  })
+
+  const rewardsWithMetadata = rewards.map((reward) => ({
+    ...reward,
+    totalKpi: referrerKpis[reward.referrer],
+    referralCount: referrerReferrals[reward.referrer],
+  }))
+
+  await resultDirectory.writeRewards(rewardsWithMetadata)
+}
+
+// Only run main if this file is being executed directly
+if (require.main === module) {
+  main(parseArgs()).catch((error) => {
+    console.error(error)
+    process.exit(1)
+  })
+}

--- a/scripts/uploadCurrentPeriodKpis.test.ts
+++ b/scripts/uploadCurrentPeriodKpis.test.ts
@@ -6,6 +6,7 @@ import { calculateKpi } from './calculateKpi'
 import { uploadFilesToGCS } from './utils/uploadFileToCloudStorage'
 import { ResultDirectory } from '../src/resultDirectory'
 import { main as calculateRewardsCeloPG } from './calculateRewards/celoPG'
+import { main as createRewardPoolWithKpiTxAndSimulateRewards } from './createRewardPoolWithKpiTxAndSimulateRewards'
 import { NetworkId } from './types'
 
 // Mock all the dependencies
@@ -20,6 +21,7 @@ jest.mock('./calculateKpi/protocols', () => ({
     'celo-pg': (...args: unknown[]) => mockHandler(...args),
   },
 }))
+jest.mock('./createRewardPoolWithKpiTxAndSimulateRewards')
 
 const mockFetchReferrals = jest.mocked(fetchReferrals)
 const mockCalculateKpi = jest.mocked(calculateKpi)
@@ -126,12 +128,28 @@ describe('uploadCurrentPeriodKpis', () => {
         },
       ],
     },
+    {
+      providerAddress: '0x0',
+      rewardsPoolAddress: '0x1',
+      networkId: NetworkId['celo-mainnet'],
+      valoraRewardsPoolAddress: null,
+      protocol: 'celo-pg-s1',
+      useRewardPoolWithKpi: true,
+      rewardsPeriods: [
+        {
+          startTimestamp: '2025-06-14T00:00:00Z',
+          endTimestampExclusive: '2025-06-21T00:00:00Z',
+          rewardAmount: '100000',
+        },
+      ],
+    },
   ]
   const defaultArgs = {
     dryRun: false,
     calculationTimestamp: '2025-06-15T14:45:00Z',
     redisConnection: 'redis://localhost:6379',
     protocols: 'celo-pg',
+    kpiFunctionId: '1234567890',
   }
 
   beforeEach(() => {
@@ -219,7 +237,7 @@ describe('uploadCurrentPeriodKpis', () => {
       )
 
       // Should call fetchReferrals for all active campaigns
-      expect(mockFetchReferrals).toHaveBeenCalledTimes(3)
+      expect(mockFetchReferrals).toHaveBeenCalledTimes(4)
       expect(mockFetchReferrals).toHaveBeenCalledWith(
         expect.objectContaining({
           protocol: 'celo-pg',
@@ -233,6 +251,11 @@ describe('uploadCurrentPeriodKpis', () => {
       expect(mockFetchReferrals).toHaveBeenCalledWith(
         expect.objectContaining({
           protocol: 'celo-transactions',
+        }),
+      )
+      expect(mockFetchReferrals).toHaveBeenCalledWith(
+        expect.objectContaining({
+          protocol: 'celo-pg-s1',
         }),
       )
     })
@@ -300,6 +323,25 @@ describe('uploadCurrentPeriodKpis', () => {
         'divvi-campaign-data-production',
         true,
       )
+    })
+  })
+
+  describe('reward pool with kpi', () => {
+    it('should call createRewardPoolWithKpiTxAndSimulateRewards', async () => {
+      await uploadCurrentPeriodKpis(
+        { ...defaultArgs, protocols: 'celo-pg-s1' },
+        mockCampaigns,
+      )
+
+      expect(createRewardPoolWithKpiTxAndSimulateRewards).toHaveBeenCalledWith({
+        protocol: 'celo-pg-s1',
+        kpiFunctionId: '1234567890',
+        startTimestamp: '2025-06-14T00:00:00Z',
+        endTimestampExclusive: '2025-06-21T00:00:00Z',
+        rewardAmount: '100000',
+        excludedReferrers: {},
+        resultDirectory: expect.any(Object),
+      })
     })
   })
 })

--- a/scripts/uploadCurrentPeriodKpis.ts
+++ b/scripts/uploadCurrentPeriodKpis.ts
@@ -7,6 +7,7 @@ import { uploadFilesToGCS } from './utils/uploadFileToCloudStorage'
 import yargs from 'yargs'
 import { ResultDirectory } from '../src/resultDirectory'
 import { Campaign, campaigns } from '../src/campaigns'
+import { main as createRewardPoolWithKpiTxAndSimulateRewards } from './createRewardPoolWithKpiTxAndSimulateRewards'
 
 async function getArgs() {
   const argv = await yargs
@@ -32,6 +33,11 @@ async function getArgs() {
       type: 'string',
       description:
         'redis connection string, to run locally use redis://127.0.0.1:6379',
+    })
+    .option('kpi-function-id', {
+      type: 'string',
+      description: 'the kpi function id (e.g., github commit hash)',
+      demandOption: true,
     }).argv
 
   return {
@@ -39,6 +45,7 @@ async function getArgs() {
     calculationTimestamp: argv['calculation-timestamp'],
     redisConnection: argv['redis-connection'],
     protocols: argv['protocols'],
+    kpiFunctionId: argv['kpi-function-id'],
   }
 }
 
@@ -164,6 +171,26 @@ export async function uploadCurrentPeriodKpis(
     const outputFilePathCsv = join(outputDir, 'kpi.csv')
     const outputFilePathJson = join(outputDir, 'kpi.json')
     const campaignFilePaths = [outputFilePathCsv, outputFilePathJson]
+
+    if (campaign.useRewardPoolWithKpi && currentPeriod.rewardAmount) {
+      await createRewardPoolWithKpiTxAndSimulateRewards({
+        resultDirectory,
+        startTimestamp: currentPeriod.startTimestamp,
+        endTimestampExclusive: currentPeriod.endTimestampExclusive,
+        rewardAmount: currentPeriod.rewardAmount,
+        protocol: campaign.protocol,
+        excludedReferrers: {},
+        kpiFunctionId: args.kpiFunctionId,
+      })
+      const rewardsFilePathCsv = join(outputDir, 'rewards.csv')
+      const rewardsFilePathJson = join(outputDir, 'rewards.json')
+      const safeTransactionsJson = join(outputDir, 'safe-transactions.json')
+      campaignFilePaths.push(
+        rewardsFilePathCsv,
+        rewardsFilePathJson,
+        safeTransactionsJson,
+      )
+    }
 
     if (currentPeriod.calculateRewards) {
       await currentPeriod.calculateRewards({

--- a/scripts/utils/createSafeTransactionsBatch.test.ts
+++ b/scripts/utils/createSafeTransactionsBatch.test.ts
@@ -1,6 +1,9 @@
 import { writeFileSync, mkdirSync } from 'fs'
 import { dirname } from 'path'
-import { createAddRewardSafeTransactionJSON } from './createSafeTransactionsBatch'
+import {
+  createAddRewardSafeTransactionJSON,
+  createUpdateKpiAndProcessRewardsSafeTransactionJSON,
+} from './createSafeTransactionsBatch'
 
 // Mock fs and path modules
 jest.mock('fs', () => ({
@@ -238,6 +241,90 @@ describe('createAddRewardSafeTransactionJSON', () => {
       expect(secondRewards).toEqual(
         '[["0x1111111111111111111111111111111111111111", "1000000000000000000", "0xef2e1fcded1ae3b33d51b37f94ead3acd4f57529223bea1c170fc2ca54a5e1d2"]]',
       )
+    })
+  })
+})
+
+describe('createUpdateKpiAndProcessRewardsSafeTransactionJSON', () => {
+  const mockFilePath = 'test-transactions.json'
+  const mockRewardPoolAddress = '0x1234567890123456789012345678901234567890'
+  const mockKpis = [
+    {
+      referrer: '0x1111111111111111111111111111111111111111',
+      kpi: BigInt('1000000000000000000'),
+    },
+    {
+      referrer: '0x2222222222222222222222222222222222222222',
+      kpi: BigInt('2000000000000000000'),
+    },
+  ]
+  const mockKpiFunctionId = '0x1234567890123456789012345678901234567890'
+  const mockRewardAmount = BigInt('1000000000000000000')
+  const mockStartTimestamp = new Date('2023-03-01T00:00:00Z')
+  const mockEndTimestampExclusive = new Date('2023-04-01T00:00:00Z')
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('should create directory and write transaction batch JSON to file', () => {
+    createUpdateKpiAndProcessRewardsSafeTransactionJSON({
+      filePath: mockFilePath,
+      rewardPoolAddress: mockRewardPoolAddress,
+      kpis: mockKpis,
+      kpiFunctionId: mockKpiFunctionId,
+      rewardAmount: mockRewardAmount,
+      startTimestamp: mockStartTimestamp,
+      endTimestampExclusive: mockEndTimestampExclusive,
+    })
+
+    expect(dirname).toHaveBeenCalledWith(mockFilePath)
+    expect(mkdirSync).toHaveBeenCalledWith('test-directory', {
+      recursive: true,
+    })
+
+    expect(writeFileSync).toHaveBeenCalledTimes(1)
+    expect(writeFileSync).toHaveBeenCalledWith(
+      mockFilePath,
+      expect.any(String),
+      { encoding: 'utf-8' },
+    )
+
+    const transactionJSON = JSON.parse(
+      (writeFileSync as jest.Mock).mock.calls[0][1],
+    )
+    expect(transactionJSON).toEqual({
+      meta: {},
+      transactions: [
+        {
+          to: '0x1234567890123456789012345678901234567890',
+          value: '0',
+          data: null,
+          contractMethod: expect.objectContaining({
+            name: 'updatePeriodKpis',
+          }),
+          contractInputsValues: {
+            kpis: `[["0x1111111111111111111111111111111111111111", "1000000000000000000"], ["0x2222222222222222222222222222222222222222", "2000000000000000000"]]`,
+            periodStart: '1677628800',
+            periodEndExclusive: '1680307200',
+            kpiFunctionId:
+              '0x0000000000000000000000001234567890123456789012345678901234567890',
+          },
+        },
+        {
+          to: '0x1234567890123456789012345678901234567890',
+          value: '0',
+          data: null,
+          contractMethod: expect.objectContaining({
+            name: 'processPeriod',
+          }),
+          contractInputsValues: {
+            periodStart: '1677628800',
+            periodEndExclusive: '1680307200',
+            totalRewardAmount: '1000000000000000000',
+          },
+        },
+      ],
     })
   })
 })

--- a/scripts/utils/createSafeTransactionsBatch.ts
+++ b/scripts/utils/createSafeTransactionsBatch.ts
@@ -1,6 +1,7 @@
 import { writeFileSync, mkdirSync } from 'fs'
 import { dirname } from 'path'
-import { keccak256, toBytes } from 'viem'
+import { keccak256, pad, toBytes } from 'viem'
+import { rewardPoolWithKpiAbi } from '../../abis/RewardPoolWithKpi'
 
 // ABI definitions for both versions of addRewards
 const LEGACY_ADD_REWARDS_ABI = {
@@ -114,6 +115,77 @@ export const createAddRewardSafeTransactionJSON = ({
         data: null,
         contractMethod,
         contractInputsValues,
+      },
+    ],
+  }
+
+  // Create directory if it doesn't exist
+  mkdirSync(dirname(filePath), { recursive: true })
+  writeFileSync(filePath, JSON.stringify(transactionsBatch, null, 2) + '\n', {
+    encoding: 'utf-8',
+  })
+}
+
+export const createUpdateKpiAndProcessRewardsSafeTransactionJSON = ({
+  filePath,
+  rewardPoolAddress,
+  kpis,
+  kpiFunctionId,
+  rewardAmount,
+  startTimestamp,
+  endTimestampExclusive,
+}: {
+  filePath: string
+  rewardPoolAddress: string
+  kpis: {
+    referrer: string
+    kpi: bigint
+  }[]
+  kpiFunctionId: string
+  rewardAmount: bigint
+  startTimestamp: Date
+  endTimestampExclusive: Date
+}) => {
+  const periodStart = BigInt(startTimestamp.getTime() / 1000).toString()
+  const periodEndExclusive = BigInt(
+    endTimestampExclusive.getTime() / 1000,
+  ).toString()
+  const updatePeriodKpisMethod = rewardPoolWithKpiAbi.find(
+    (item) => item.type === 'function' && item.name === 'updatePeriodKpis',
+  )
+  const processPeriodMethod = rewardPoolWithKpiAbi.find(
+    (item) => item.type === 'function' && item.name === 'processPeriod',
+  )
+
+  const updatePeriodKpisMethodInputs = {
+    kpis: `[${kpis.map((kpi) => `["${kpi.referrer}", "${kpi.kpi}"]`).join(', ')}]`,
+    periodStart,
+    periodEndExclusive,
+    kpiFunctionId: pad(kpiFunctionId as `0x${string}`, { size: 32 }),
+  }
+
+  const processPeriodMethodInputs = {
+    periodStart,
+    periodEndExclusive,
+    totalRewardAmount: rewardAmount.toString(),
+  }
+
+  const transactionsBatch = {
+    meta: {},
+    transactions: [
+      {
+        to: rewardPoolAddress,
+        value: '0',
+        data: null,
+        contractMethod: updatePeriodKpisMethod,
+        contractInputsValues: updatePeriodKpisMethodInputs,
+      },
+      {
+        to: rewardPoolAddress,
+        value: '0',
+        data: null,
+        contractMethod: processPeriodMethod,
+        contractInputsValues: processPeriodMethodInputs,
       },
     ],
   }

--- a/src/campaigns.ts
+++ b/src/campaigns.ts
@@ -10,27 +10,47 @@ import { main as calculateRewardsLiskV0 } from '../scripts/calculateRewards/lisk
 import { main as calculateRewardsBaseV0 } from '../scripts/calculateRewards/baseV0'
 import { main as calculateRewardsTetherV0 } from '../scripts/calculateRewards/tetherV0'
 
-export type Campaign = {
+type CampaignBase = {
   providerAddress: Address
   protocol: Protocol
   rewardsPoolAddress: Address
   networkId: NetworkId
-  rewardsPeriods: {
-    startTimestamp: string
-    endTimestampExclusive: string
-    calculateRewards?: (args: {
-      resultDirectory: ResultDirectory
-      startTimestamp: string
-      endTimestampExclusive: string
-    }) => Promise<void>
-    calculateRewardSlices?: (args: {
-      resultDirectory: ResultDirectory
-      startTimestamp: string
-      endTimestampExclusive: string
-    }) => Promise<void>
-  }[]
-  valoraRewardsPoolAddress: Address | null // reward pool for redistributing valora rewards
+  valoraRewardsPoolAddress: Address | null
 }
+
+type CalculateRewardsArgs = (args: {
+  resultDirectory: ResultDirectory
+  startTimestamp: string
+  endTimestampExclusive: string
+}) => Promise<void>
+
+type RewardPeriodWithKpi = {
+  startTimestamp: string
+  endTimestampExclusive: string
+  rewardAmount: string
+  calculateRewards?: never
+  calculateRewardSlices?: CalculateRewardsArgs
+}
+
+type RewardPeriodWithoutKpi = {
+  startTimestamp: string
+  endTimestampExclusive: string
+  rewardAmount?: never
+  calculateRewards?: CalculateRewardsArgs
+  calculateRewardSlices?: CalculateRewardsArgs
+}
+
+export type Campaign = CampaignBase &
+  (
+    | {
+        useRewardPoolWithKpi: true
+        rewardsPeriods: RewardPeriodWithKpi[]
+      }
+    | {
+        useRewardPoolWithKpi?: false
+        rewardsPeriods: RewardPeriodWithoutKpi[]
+      }
+  )
 
 const excludedReferrersFromTetherV0 = [
   [


### PR DESCRIPTION
For ENG-596, update periodic kpi job to support both on-chain and off-chain reward calculations.
For on-chain calculations, the script:
- creates a safe tx batch to upload kpis (using `updatePeriodKpis`) and then issue rewards (using `processPeriod`)
- simulates reward calculation by calling the library contract directly to create the rewards.json/csv files