### PR TITLE
feat(tetherV0): use alternate address for claiming beefy rewards

### DIFF
--- a/scripts/calculateRewards/tetherV0.ts
+++ b/scripts/calculateRewards/tetherV0.ts
@@ -13,8 +13,8 @@ import { parse } from 'csv-parse/sync'
 const REWARD_POOL_ADDRESS = '0xB575210cdF52B18000aE24Be4981e9ABC7716F98' // on Ethereum mainnet
 
 // Delegation mapping for Safes that can't claim on this chain
-const BEEFY_SAFE_ADDRESS = '0x0000000000000000000000000000000000000000' // TODO: Replace with Beefy's Safe address
-const BEEFY_EOA_ADDRESS = '0x0000000000000000000000000000000000000000' // TODO: Replace with Beefy's EOA address
+const BEEFY_SAFE_ADDRESS = '0x4aba01fb8e1f6bfe80c56deb367f19f35df0f4ae'
+const BEEFY_EOA_ADDRESS = '0xc9c61194682a3a5f56bf9cd5b59ee63028ab6041'
 
 function parseArgs() {
   const args = yargs

--- a/scripts/calculateRewards/tetherV0.ts
+++ b/scripts/calculateRewards/tetherV0.ts
@@ -12,6 +12,10 @@ import { parse } from 'csv-parse/sync'
 
 const REWARD_POOL_ADDRESS = '0xB575210cdF52B18000aE24Be4981e9ABC7716F98' // on Ethereum mainnet
 
+// Delegation mapping for Safes that can't claim on this chain
+const BEEFY_SAFE_ADDRESS = '0x0000000000000000000000000000000000000000' // TODO: Replace with Beefy's Safe address
+const BEEFY_EOA_ADDRESS = '0x0000000000000000000000000000000000000000' // TODO: Replace with Beefy's EOA address
+
 function parseArgs() {
   const args = yargs
     .option('datadir', {
@@ -124,10 +128,19 @@ export async function main(args: ReturnType<typeof parseArgs>) {
     totalValue: reward.kpi,
   }))
 
+  // Apply delegation mapping for Safes that can't claim on this chain
+  const rewardsWithDelegation = rewards.map((reward) => ({
+    ...reward,
+    referrerId:
+      reward.referrerId.toLowerCase() === BEEFY_SAFE_ADDRESS.toLowerCase()
+        ? BEEFY_EOA_ADDRESS
+        : reward.referrerId,
+  }))
+
   createAddRewardSafeTransactionJSON({
     filePath: resultDirectory.safeTransactionsFilePath,
     rewardPoolAddress: REWARD_POOL_ADDRESS,
-    rewards,
+    rewards: rewardsWithDelegation,
     startTimestamp,
     endTimestampExclusive,
     useIdempotency: true,


### PR DESCRIPTION
Quick fix for ENG-638

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Map the Beefy Safe referrer to an EOA and use the mapped rewards when creating tetherV0 Safe transaction batch.
> 
> - **tetherV0 rewards script (`scripts/calculateRewards/tetherV0.ts`)**:
>   - Add delegation mapping constants: `BEEFY_SAFE_ADDRESS` -> `BEEFY_EOA_ADDRESS`.
>   - Transform `rewards` to `rewardsWithDelegation` by replacing `referrerId` when it matches the Beefy Safe.
>   - Use `rewardsWithDelegation` in `createAddRewardSafeTransactionJSON`.
>   - Retain metadata augmentation (`rewardsWithMetadata`) and file outputs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0dbeed7fce0875290c2bca21c23b015a55cd4c29. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->