### PR TITLE
fix: memory error in updateDivviEntities

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -141,4 +141,5 @@ jobs:
           yarn deploy:production:internal-single updateDivviEntities \
             --env-vars-file=cloud-functions/endpoints/updateDivviEntities/config-production.yaml \
             --set-secrets GOOGLE_SERVICE_ACCOUNT_JSON=BUILDER_INFO_SERVICE_ACCOUNT_JSON:latest \
-            --set-secrets BUILDER_INFO_GOOGLE_SHEET_ID=BUILDER_INFO_GOOGLE_SHEET_ID:latest
+            --set-secrets BUILDER_INFO_GOOGLE_SHEET_ID=BUILDER_INFO_GOOGLE_SHEET_ID:latest \
+            --memory=512MiB


### PR DESCRIPTION
I'm seeing regular out of memory errors from this function. [Logs](https://console.cloud.google.com/logs/query;query=resource.type%3D%22cloud_run_revision%22%0A--%20resource.labels.service_name%3D%22sendregisterreferraltransactions%22%0Aseverity%3D%22ERROR%22%0Aresource.labels.service_name%3D%22updatedivvientities%22;cursorTimestamp=2025-10-07T02:00:12.142252Z;duration=P2D?referrer=search&project=divvi-production). This PR bumps the memory to the next tier.