### PR TITLE
Update stage function for cycle 3

### DIFF
--- a/scripts/calculateRewards/celoPGS1.ts
+++ b/scripts/calculateRewards/celoPGS1.ts
@@ -4,6 +4,7 @@ import {
   calculateRewards,
   calculateStageV0,
   calculateStageV1,
+  calculateStageV2,
   getQualityUserScores,
 } from '../../src/celoPGRewards'
 import { KpiRow, ResultDirectory } from '../../src/resultDirectory'
@@ -29,7 +30,7 @@ async function readKpiFile(url: string) {
   }
 }
 
-const stageFunctions = [calculateStageV0, calculateStageV1]
+const stageFunctions = [calculateStageV0, calculateStageV1, calculateStageV2]
 
 function parseArgs() {
   const args = yargs

--- a/src/campaigns.ts
+++ b/src/campaigns.ts
@@ -4,7 +4,7 @@ import { main as calculateRewardsTetherV0 } from '../scripts/calculateRewards/te
 import { toPeriodFolderName } from '../scripts/utils/dateFormatting'
 import { Campaign } from './types'
 import { pastCampaigns } from './pastCampaings'
-import { calculateStageV0, calculateStageV1 } from './celoPGRewards'
+import { calculateStageV0, calculateStageV1, calculateStageV2 } from './celoPGRewards'
 import { google } from 'googleapis'
 import { isAddress } from 'viem'
 
@@ -357,7 +357,7 @@ const celoPGS1Campaign: Campaign = {
           rewardAmount: '25000',
           excludedReferrers: mergedExcludedReferrers,
           previousKpiFiles: celoPGS1PreviousKpiFiles(index),
-          stageFunction: calculateStageV1,
+          stageFunction: calculateStageV2,
         })
       },
     },
@@ -382,7 +382,7 @@ const celoPGS1Campaign: Campaign = {
           rewardAmount: '25000',
           excludedReferrers: mergedExcludedReferrers,
           previousKpiFiles: celoPGS1PreviousKpiFiles(index),
-          stageFunction: calculateStageV1,
+          stageFunction: calculateStageV2,
         })
       },
     },
@@ -407,7 +407,7 @@ const celoPGS1Campaign: Campaign = {
           rewardAmount: '25000',
           excludedReferrers: mergedExcludedReferrers,
           previousKpiFiles: celoPGS1PreviousKpiFiles(index),
-          stageFunction: calculateStageV1,
+          stageFunction: calculateStageV2,
         })
       },
     },
@@ -432,7 +432,7 @@ const celoPGS1Campaign: Campaign = {
           rewardAmount: '25000',
           excludedReferrers: mergedExcludedReferrers,
           previousKpiFiles: celoPGS1PreviousKpiFiles(index),
-          stageFunction: calculateStageV1,
+          stageFunction: calculateStageV2,
         })
       },
     },
@@ -457,7 +457,7 @@ const celoPGS1Campaign: Campaign = {
           rewardAmount: '25000',
           excludedReferrers: mergedExcludedReferrers,
           previousKpiFiles: celoPGS1PreviousKpiFiles(index),
-          stageFunction: calculateStageV1,
+          stageFunction: calculateStageV2,
         })
       },
     },
@@ -482,7 +482,7 @@ const celoPGS1Campaign: Campaign = {
           rewardAmount: '25000',
           excludedReferrers: mergedExcludedReferrers,
           previousKpiFiles: celoPGS1PreviousKpiFiles(index),
-          stageFunction: calculateStageV1,
+          stageFunction: calculateStageV2,
         })
       },
     },

--- a/src/celoPGRewards.ts
+++ b/src/celoPGRewards.ts
@@ -107,6 +107,28 @@ export function calculateStageV1({
   }
 }
 
+export function calculateStageV2({
+  uniqueWallets,
+  gasUsage,
+}: {
+  uniqueWallets: number
+  gasUsage: bigint
+}) {
+  if (uniqueWallets >= 100_000 && gasUsage >= 500_000_000_000n) {
+    return 5
+  } else if (uniqueWallets >= 10_000 && gasUsage >= 25_000_000_000n) {
+    return 4
+  } else if (uniqueWallets >= 2_500 && gasUsage >= 2_500_000_000n) {
+    return 3
+  } else if (uniqueWallets >= 100 && gasUsage >= 250_000_000n) {
+    return 2
+  } else if (uniqueWallets >= 10 && gasUsage >= 25_000_000n) {
+    return 1
+  } else {
+    return 0
+  }
+}
+
 export function calculateRewards({
   kpiData,
   rewards,


### PR DESCRIPTION
Implement `calculateStageV2` to update Stage 1 gas requirements for Celo PG campaigns from Cycle 3 onwards.

---
Linear Issue: [ENG-670](https://linear.app/valora/issue/ENG-670/chore-update-stage-function-for-cycle-3)

<a href="https://cursor.com/background-agent?bcId=bc-bb77f323-92e8-467a-a6f5-c926d24b4efd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-bb77f323-92e8-467a-a6f5-c926d24b4efd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

